### PR TITLE
Add GitHub repository button to hero section

### DIFF
--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -13,6 +13,7 @@ permalink: /
   <div class="hero-actions">
     <a href="#hero" class="button">Get Started</a>
     <a href="{{ '/overview/' | relative_url }}" class="button-ghost">See it in action →</a>
+    <a href="https://github.com/griddynamics/rosetta" class="button-ghost" target="_blank" rel="noopener noreferrer">GitHub →</a>
   </div>
 </section>
 


### PR DESCRIPTION
Adds a third CTA button in the hero-main section linking to the griddynamics/rosetta GitHub repository, opening in a new tab.

Made-with: Cursor