### PR TITLE
Add trust badge to highlight privacy message on homepage

### DIFF
--- a/docs/web/assets/styles.css
+++ b/docs/web/assets/styles.css
@@ -665,6 +665,40 @@ h2.with-marker::before {
 
 .qs-step--last .qs-step-body { padding-bottom: 0; }
 
+/* Trust badge */
+.qs-trust-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: .65rem;
+  margin-top: .9rem;
+  margin-bottom: 1.2rem;
+  padding: .7rem 1.15rem;
+  background: rgba(72, 187, 120, 0.1);
+  border: 1.5px solid rgba(72, 187, 120, 0.3);
+  border-radius: 10px;
+  font-size: .82rem;
+  font-weight: 500;
+  color: var(--text);
+  line-height: 1.45;
+}
+
+.qs-trust-icon {
+  flex-shrink: 0;
+  color: #48bb78;
+}
+
+[data-theme="light"] .qs-trust-badge {
+  background: rgba(39, 120, 78, 0.09);
+  border-color: rgba(39, 120, 78, 0.35);
+  color: #1a202c;
+  font-weight: 600;
+  box-shadow: 0 1px 4px rgba(39, 120, 78, 0.08);
+}
+
+[data-theme="light"] .qs-trust-icon {
+  color: #276e4e;
+}
+
 /* Success banner */
 .qs-success {
   display: flex;

--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -126,7 +126,10 @@ permalink: /
         <div class="qs-step-body">
           <h3 class="qs-step-title">Add Rosetta MCP to your IDE</h3>
           <p class="qs-step-desc">Pick your editor. No local install needed — Rosetta connects over HTTP.</p>
-          <p class="qs-step-note">Rosetta is designed to never use or see your data or IP.</p>
+          <div class="qs-trust-badge">
+            <svg class="qs-trust-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+            <span>Rosetta is designed to never use or see your data or IP.</span>
+          </div>
 
           <div class="qs-tabs-scroll">
             <div class="qs-tabs" role="tablist">


### PR DESCRIPTION
Replace plain text note with a styled trust badge (shield icon + green border) to make the "never use or see your data or IP" message visually prominent.