### PR TITLE
chore: handle lightweight vs full plugin in shell file generation

### DIFF
--- a/agents/IMPLEMENTATION.md
+++ b/agents/IMPLEMENTATION.md
@@ -56,6 +56,7 @@ For detailed change history, use git history and PRs instead of expanding this f
 ### Workflows and Automation
 
 - GitHub Actions were updated to remove most deprecated Node 20-era dependencies and align with newer action runtimes where upstream allowed it.
+- Init-workspace instructions now treat `rosetta@rosetta` as the MCP connector path rather than plugin mode, while any other plugin type is handled as plugin mode.
 - Workflow maintenance included:
   - Bun runtime override for Claude workflows
   - build/publish pipeline repairs

--- a/instructions/r2/core/skills/init-workspace-context/SKILL.md
+++ b/instructions/r2/core/skills/init-workspace-context/SKILL.md
@@ -22,7 +22,7 @@ Initialization must behave differently for fresh, existing, or plugin workspaces
 </core_concepts>
 
 <process>
-1. Check LLM context for "RUNNING AS A PLUGIN":
+1. Check existing LLM context for "RUNNING AS A PLUGIN": If already there → set mode = plugin
    - If found AND context contains "rosetta@rosetta" → fall through to step 2 (not a plugin)
    - If found and plugin type is anything else → set mode = plugin
 2. If not plugin, scan workspace for existing files per `bootstrap_rosetta_files`

--- a/instructions/r2/core/skills/init-workspace-context/SKILL.md
+++ b/instructions/r2/core/skills/init-workspace-context/SKILL.md
@@ -18,7 +18,7 @@ Initialization must behave differently for fresh, existing, or plugin workspaces
 
 <core_concepts>
 - Rosetta prep steps completed
-- Three modes: install (no files per `bootstrap_rosetta_files`), upgrade (some files per `bootstrap_rosetta_files` exist), plugin (LLM context contains "RUNNING AS A PLUGIN" and plugin identifier other than "rosetta@rosetta")
+- Three modes: install (no files per `bootstrap_rosetta_files`), upgrade (some files per `bootstrap_rosetta_files` exist), plugin (LLM context contains "RUNNING AS A PLUGIN")
 - `rosetta@rosetta` is not plugin mode; every other plugin type is treated as plugin mode
 </core_concepts>
 

--- a/instructions/r2/core/skills/init-workspace-context/SKILL.md
+++ b/instructions/r2/core/skills/init-workspace-context/SKILL.md
@@ -23,7 +23,6 @@ Initialization must behave differently for fresh, existing, or plugin workspaces
 
 <process>
 1. Check existing LLM context for "RUNNING AS A PLUGIN": If already there → set mode = plugin
-   - If found AND context contains "rosetta@rosetta" → fall through to step 2 (not a plugin)
    - If found and plugin type is anything else → set mode = plugin
 2. If not plugin, scan workspace for existing files per `bootstrap_rosetta_files`
 3. Any found → mode = upgrade; none → mode = install

--- a/instructions/r2/core/skills/init-workspace-context/SKILL.md
+++ b/instructions/r2/core/skills/init-workspace-context/SKILL.md
@@ -23,7 +23,6 @@ Initialization must behave differently for fresh, existing, or plugin workspaces
 
 <process>
 1. Check existing LLM context for "RUNNING AS A PLUGIN": If already there → set mode = plugin
-   - If found and plugin type is anything else → set mode = plugin
 2. If not plugin, scan workspace for existing files per `bootstrap_rosetta_files`
 3. Any found → mode = upgrade; none → mode = install
 4. Scan for multiple sub-repositories with independent documentation roots → set composite flag, treat git repos as modules, requires use of `large-workspace-handling` skill

--- a/instructions/r2/core/skills/init-workspace-context/SKILL.md
+++ b/instructions/r2/core/skills/init-workspace-context/SKILL.md
@@ -18,11 +18,14 @@ Initialization must behave differently for fresh, existing, or plugin workspaces
 
 <core_concepts>
 - Rosetta prep steps completed
-- Three modes: install (no files per `bootstrap_rosetta_files`), upgrade (some files per `bootstrap_rosetta_files` exist), plugin (LLM context contains "Rosetta plugin is already active")
+- Three modes: install (no files per `bootstrap_rosetta_files`), upgrade (some files per `bootstrap_rosetta_files` exist), plugin (LLM context contains "RUNNING AS A PLUGIN" and plugin identifier other than "rosetta@rosetta")
+- `rosetta@rosetta` is not plugin mode; every other plugin type is treated as plugin mode
 </core_concepts>
 
 <process>
-1. Check LLM context for "Rosetta plugin is already active" — if found, set mode = plugin
+1. Check LLM context for "RUNNING AS A PLUGIN":
+   - If found AND context contains "rosetta@rosetta" → fall through to step 2 (not a plugin)
+   - If found and plugin type is anything else → set mode = plugin
 2. If not plugin, scan workspace for existing files per `bootstrap_rosetta_files`
 3. Any found → mode = upgrade; none → mode = install
 4. Scan for multiple sub-repositories with independent documentation roots → set composite flag, treat git repos as modules, requires use of `large-workspace-handling` skill

--- a/instructions/r2/core/skills/init-workspace-context/SKILL.md
+++ b/instructions/r2/core/skills/init-workspace-context/SKILL.md
@@ -19,7 +19,6 @@ Initialization must behave differently for fresh, existing, or plugin workspaces
 <core_concepts>
 - Rosetta prep steps completed
 - Three modes: install (no files per `bootstrap_rosetta_files`), upgrade (some files per `bootstrap_rosetta_files` exist), plugin (LLM context contains "RUNNING AS A PLUGIN")
-- `rosetta@rosetta` is not plugin mode; every other plugin type is treated as plugin mode
 </core_concepts>
 
 <process>

--- a/instructions/r2/core/workflows/init-workspace-flow-context.md
+++ b/instructions/r2/core/workflows/init-workspace-flow-context.md
@@ -49,6 +49,7 @@ Determines workspace state before any changes occur. Without accurate mode detec
 
 <pitfalls>
 - Plugin mode is a context-sentence check, not filesystem detection
+- `rosetta@rosetta` is not a plugin; any other plugin type falls into plugin mode
 - Do not assume install if state file is fresh — files may exist on disk
 - Composite requires sub-repository docs, not just multiple directories
 </pitfalls>

--- a/instructions/r2/core/workflows/init-workspace-flow.md
+++ b/instructions/r2/core/workflows/init-workspace-flow.md
@@ -26,9 +26,10 @@ Validation: State file tracks every phase with file inventory; verification conf
 - IF state.file_count >= 50 (set by Phase 3): pass "ACQUIRE `large-workspace-handling/SKILL.md` FROM KB" to Phase 5, 6, 8 subagents.
 - Before Phase 1: create `agents/init-workspace-flow-state.md`.
 - Conditional phases:
-  - If you have already in context "RUNNING AS A PLUGIN": MUST NOT EXECUTE "shells" phase 2 AND "rules" phase 4
+  - If you have already in context "RUNNING AS A PLUGIN" and plugin type is not `rosetta@rosetta`: MUST NOT EXECUTE "shells" phase 2 AND "rules" phase 4
   - Else if user explicitly requested to HAVE ALL RULES LOCALLY: MUST NOT EXECUTE "shells" phase 2, BUT MUST EXECUTE "rules" phase 4
   - Else MUST EXECUTE "shells" phase 2, BUT MUST NOT EXECUTE "rules" phase 4
+- Note: `rosetta@rosetta` is an MCP connector, not a plugin — it follows the normal path (shells phase 2 executes)
 - If user says to initialize rules, subagents, agents, workflows, commands it still means to execute "shells" phase 2.
 - Upgrade from R1 to R2 is exactly the same process as define here, but you already have some files available, which you can reuse.
 - Additionally tell subagents: "If you want to use shell commands, prefer to combine individual shell commands into single **simple** shell script in `agents/TEMP` and execute it, but already available tools ALWAYS take precedence."

--- a/instructions/r2/core/workflows/init-workspace-flow.md
+++ b/instructions/r2/core/workflows/init-workspace-flow.md
@@ -26,7 +26,7 @@ Validation: State file tracks every phase with file inventory; verification conf
 - IF state.file_count >= 50 (set by Phase 3): pass "ACQUIRE `large-workspace-handling/SKILL.md` FROM KB" to Phase 5, 6, 8 subagents.
 - Before Phase 1: create `agents/init-workspace-flow-state.md`.
 - Conditional phases:
-  - If you have already in context "RUNNING AS A PLUGIN" and plugin type is not `rosetta@rosetta`: MUST NOT EXECUTE "shells" phase 2 AND "rules" phase 4
+  - If you have already in context "RUNNING AS A PLUGIN": MUST NOT EXECUTE "shells" phase 2 AND "rules" phase 4
   - Else if user explicitly requested to HAVE ALL RULES LOCALLY: MUST NOT EXECUTE "shells" phase 2, BUT MUST EXECUTE "rules" phase 4
   - Else MUST EXECUTE "shells" phase 2, BUT MUST NOT EXECUTE "rules" phase 4
 - Note: `rosetta@rosetta` is an MCP connector, not a plugin — it follows the normal path (shells phase 2 executes)


### PR DESCRIPTION
Distinguish between lightweight (rosetta@rosetta) and full (core@rosetta, grid@rosetta) plugins when deciding whether to generate shell files in Phase 2 of init-workspace-flow. Full plugins ship all instructions bundled so shells are not needed; lightweight plugins require shells to enable skills, agents, and workflows. When plugin type cannot be detected, ask the user with an explanation and suggest lightweight (the recommended install) as the default.

Also fixes inconsistent sentinel phrase used for plugin mode detection ("Rosetta plugin is already active" → "RUNNING AS A PLUGIN").