### PR TITLE
fix bug #1183 prompt validation

### DIFF
--- a/.github/workflows/validate-prompts.yml
+++ b/.github/workflows/validate-prompts.yml
@@ -60,16 +60,22 @@ jobs:
         run: |
           echo "Detecting changed files in instructions/ folder..."
 
-          # Get the base branch (target of the PR)
-          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
-          echo "Base branch: $BASE_BRANCH"
+          if [ -n "${{ github.event.pull_request.base.ref }}" ]; then
+            BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+            git fetch origin "$BASE_BRANCH"
+            BASE_REF="origin/$BASE_BRANCH"
+          else
+            BASE_REF="HEAD^"
+          fi
+
+          echo "Base ref: $BASE_REF"
 
           # Get changed files in instructions/ folder
-          git fetch origin "$BASE_BRANCH"
-          CHANGED_FILES=$(git diff --name-only "origin/$BASE_BRANCH"...HEAD -- 'instructions/**/*.md' | tr '\n' ' ')
+          CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD -- 'instructions/**/*.md' 2>/dev/null | tr '\n' ' ' || true)
 
           echo "Changed files: $CHANGED_FILES"
           echo "files=$CHANGED_FILES" >> $GITHUB_OUTPUT
+          echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
 
           # Count files
           if [ -z "$CHANGED_FILES" ]; then
@@ -84,7 +90,7 @@ jobs:
         if: steps.changed-files.outputs.count > 0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          BASE_REF: ${{ steps.changed-files.outputs.base_ref }}
         run: |
           echo "Validating prompts..."
 
@@ -99,7 +105,7 @@ jobs:
 
             # Get base version - REQUIRED for comparison
             BASE_FILE="$BASE_VERSIONS_DIR/$(basename "$FILE")"
-            if git show "origin/$BASE_BRANCH:$FILE" > "$BASE_FILE" 2>/dev/null; then
+            if git show "$BASE_REF:$FILE" > "$BASE_FILE" 2>/dev/null; then
               echo "::notice::Base version found, running comparison"
               PROMPT="Compare and evaluate the prompt file versions: 
                 NEW: $FILE
@@ -140,7 +146,7 @@ jobs:
           echo "::notice::No high/critical issues found"
 
       - name: Generate PR comment
-        if: always() && steps.changed-files.outputs.count > 0
+        if: always() && github.event_name == 'pull_request' && steps.changed-files.outputs.count > 0
         run: |
           cat > $PR_COMMENT_FILE <<EOF
           ## :clipboard: Prompt Quality Validation Report
@@ -245,7 +251,7 @@ jobs:
           done
 
       - name: Post PR comment
-        if: always() && steps.changed-files.outputs.count > 0
+        if: always() && github.event_name == 'pull_request' && steps.changed-files.outputs.count > 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

Fixes prompt validation workflow failures when triggered outside of a pull request context (e.g., `workflow_dispatch` or push events).

## Problem

The `validate-prompts` workflow assumed `github.event.pull_request.base.ref` was always set, causing failures when:
- The workflow runs via `workflow_dispatch` (manual trigger) where `base.ref` is empty
- `git diff` exits non-zero when no matching instruction files are found, breaking subsequent steps
- `Generate PR comment` and `Post PR comment` steps attempted to post to a PR that does not exist in non-PR runs

## Changes

- **Fallback base ref**: When `base.ref` is not available (non-PR context), falls back to `HEAD^` instead of crashing on an empty `BASE_BRANCH`
- **Error-safe diff**: `git diff` now uses `2>/dev/null || true` to prevent step failure when no `.md` files match
- **PR-only comment steps**: `Generate PR comment` and `Post PR comment` are now gated with `github.event_name == 'pull_request'` so they are skipped gracefully on non-PR triggers
- **Consistent ref variable**: `BASE_BRANCH` env var renamed to `BASE_REF`; the resolved ref is propagated via step output (`base_ref`) so later steps handle both branch-name refs (`origin/<branch>`) and the `HEAD^` fallback correctly

## Testing

- PR trigger: existing behavior preserved — `git fetch` + diff against `origin/<base>` as before
- Manual dispatch / push: workflow now completes without error; comment steps are skipped

Fixes #1183