### PR TITLE
Extract prep steps 2 & 3 from bootstrap-core-policy into workspace-pr…

### DIFF
--- a/instructions/r2/core/rules/bootstrap-core-policy.md
+++ b/instructions/r2/core/rules/bootstrap-core-policy.md
@@ -52,39 +52,8 @@ baseSchema: docs/schemas/rule.md
 2. Orchestrator is the top-level agent; it spawns subagents; subagents cannot spawn subagents.
 3. Subagents start with fresh context every run.
 
-### Input Contract
-
-4. Subagent prompt MUST start with: assumed role/specialization, stated [lightweight|full] subagent, full path to plan.json, phase&task id, SMART tasks, `MUST USE SKILL [required]`, and `RECOMMEND USE SKILL [recommended]`.
-5. Provide specific task, full context, and references. Subagents know nothing except shared bootstrap and prep steps and this contract, always provide original user request/intent throughout all steps.
-6. Define explicit scope, expected outputs, and clear expectations. Forbid out-of-scope work.
-7. Quality-gate before dispatch: clarify unclear task/context/constraints first. Never dispatch ambiguous instructions.
-8. Lightweight = generic, built-in, small clear tasks (e.g., build/tests). Full = user-defined, specialized role, larger work.
-9. Keep standard agent tools available to subagents as required.
-10. Initialize required skills together with subagent usage.
-
-### Output Contract
-
-11. Define unique output file path per subagent.
-12. For large output, define exact path and required file format/template.
-13. Subagent must stop and report when blocked or off-plan.
-14. Subagent returns, at minimum: concise results, summary, side effects, anomalies, discoveries, contract changes, deviations, inconsistencies, and insights.
-
-### Routing & File I/O
-
-15. Route independent work in parallel and dependent work sequentially.
-16. For large input, use TEMP feature folder and provide workspace path.
-17. Define collision-safe strategy for parallel file writes.
-18. Use TEMP folder for temporary coordination.
-
-### Quality & Ownership
-
-19. Orchestrator is team manager; owns delegation quality end-to-end.
-20. Orchestrator must spawn reviewer subagents to verify delegated work. Use different model if possible.
-21. `Review` = static inspection (recommendations). `Validate` = running on real/sample tasks (catches real issues, expensive).
-22. Adopt plan changes with proper ordering/analysis. If something comes up, adapt the plan. Extra work goes later, if logical and user agrees.
-23. Keep orchestrator and subagent contexts below overload thresholds.
-24. Prefer minimal state transitions between orchestration steps.
-25. Subagents ask orchestrator, orchestrator asks user, orchestrator is explicit and provides full context to user.
+**IF:** About to spawn a subagent (orchestrator only)
+**THEN:** MUST USE SKILL `subagent-orchestration` for Input Contract, Output Contract, Routing & File I/O, and Quality & Ownership rules.
 
 </subagents_orchestration_rules>
 

--- a/instructions/r2/core/rules/bootstrap-core-policy.md
+++ b/instructions/r2/core/rules/bootstrap-core-policy.md
@@ -19,39 +19,10 @@ baseSchema: docs/schemas/rule.md
 6. Apply `Process Enforcement Rules`.
 7. MUST Always Use `Subagents Orchestration Rules`.
 
-# Prep Step 2:
+# Prep Step 2, Prep Step 3 for subagents, Prep Step 3 for orchestrator (primary/top agent):
 
-1. Rosetta server contains R2.0 of the rules; strongly suggest upgrade if workspace is older by asking user to type in a new session "Initialize this repository using Rosetta (upgrade R1 to R2)".
-2. MUST ALWAYS read the FULL CONTENT ALL LINES AT ONCE of CONTEXT.md and ARCHITECTURE.md, IT HAS CRITICAL CONTEXT.
-3. MUST ALWAYS grep `^#{1,3}` headers of the IMPLEMENTATION.md and agent MEMORY.md.
-4. Grep headers of rest Rosetta file when needed.
-5. MUST use and validate REQUIREMENTS (if exist)
-6. MUST ALWAYS EXECUTE FULLY `Prep Step 3` BEFORE you do anything else, including planning, exploring, reading, validating.
-7. Rosetta guides you EXACTLY how to do all those activities PROPERLY!
-8. MUST IDENTIFY request size AFTER CONTEXT LOADED:
-   - SMALL: 1-2 file changes/activities and only one area affected
-   - MEDIUM: up to ~10 file changes/activities and only one area affected
-   - LARGE: more than 10 file changes/activities or multiple areas affected
-9. Additional requirements based on request size:
-   - SMALL: MUST USE todo tasks for planning, MUST OUTPUT tech specs as message, MUST use workflows;
-   - MEDIUM: MUST keep documentation concise, light, and short; MUST use subagents, MUST use workflows;
-   - LARGE: MUST use subagents extensively as orchestrator context will be overloaded, MUST use workflows;
-10. Reevaluate request size and workflow when scope changes or new information is received
-11. If CONTEXT.md, ARCHITECTURE.md, IMPLEMENTATION.md, or MEMORY.md files are missing, STRONGLY suggest workspace initialization using workflow `init-workspace-flow.md`, and MUST continue with the prep steps 3.
-
-# Prep Step 3 for subagents:
-
-1. Orchestrator request -> read get_context_instructions schema (if needed) -> get_context_instructions (if not done yet) -> execute all prep steps for subagent -> proceed with the rest of actions
-2. Perform execution todo tasks level planning
-3. MUST execute todo tasks and adopt changes
-4. Proceed with request and activities
-
-# Prep Step 3 for orchestrator (primary/top agent):
-
-1. user request -> read get_context_instructions schema (if needed) -> get_context_instructions (if not done yet) -> execute all prep steps -> load workflow -> proceed with workflow and integrate the rest of actions (including questioning user, EnterPlanMode, plan_mode_respond, system-reminder, etc.)
-2. MUST ACQUIRE <workflow TAG from available workflows> FROM KB TO LOAD MATCHING WORKFLOW AND FULLY EXECUTE FOLLOWING ITS ENTIRE DEFINITION FOR ALL REQUEST SIZES
-3. In planning mode results of `planning` and `tech-specs` MUST be stored according to system prompt (NOT in `plans` folder as it is read-only)
-4. Proceed executing workflow which guides you how to handle user request and activities as user expects it
+**IF:** `workspace-prep` skill not loaded
+**THEN:** MUST USE SKILL `workspace-prep`
 
 </must>
 

--- a/instructions/r2/core/rules/bootstrap-guardrails.md
+++ b/instructions/r2/core/rules/bootstrap-guardrails.md
@@ -56,22 +56,8 @@ THEN MUST STOP, DOUBLE CHECK, "THINK THE OPPOSITE", AND ASK:
 
 <dangerous_actions>
 
-1. IF action or consequence or side-effect of action is HIGH RISK, DANGEROUS, IRREVERSIBLE, or DESTRUCTIVE
-2. THEN 
-   - MUST ALWAYS assess BLAST RADIUS
-   - "THINK THE OPPOSITE"
-   - THINK how it can be done differently
-
-Examples (not limited):
-- Deleting data from actual servers
-- Using actual servers in unit testing
-- git reset, fixing git, deleting branches
-- generating scripts or test commands that do that
-
-Exceptions (after blast radius):
-1. Does not apply to application code itself.
-2. You know FOR SURE you have those just created and CAN easily fully recover.
-3. Temporary or duplicate data you know FOR SURE without side-effects.
+**IF:** Action or consequence or side-effect of action is HIGH RISK, DANGEROUS, IRREVERSIBLE, or DESTRUCTIVE.
+**THEN:** MUST USE SKILL `dangerous-actions-handling`.
 
 </dangerous_actions>
 

--- a/instructions/r2/core/rules/bootstrap-guardrails.md
+++ b/instructions/r2/core/rules/bootstrap-guardrails.md
@@ -77,12 +77,8 @@ Exceptions (after blast radius):
 
 <sensitive_information_handling>
 
-- DO NOT read, query, store, tell, write, log, or distribute any SENSITIVE information (PII, PCI, HIPAA, PHI, GDPR, SOC2, FedRAMP, Secrets, etc)
-- IF read it, report without exposing
-- IF it is needed as-is, MUST ask for explicit user approval
-- User can override (mocked data)
-- NEVER output, echo, print, log, summarize, or reference the raw value of any sensitive data in chat or in any file.
-- USE masking or substring. IF a secret value is encountered in any context (file read, tool output, code, logs), MASK it immediately using the format `[REDACTED:<type>]` (e.g. `[REDACTED:API_KEY]`, `[REDACTED:PASSWORD]`).
+**IF:** Sensitive or possibly-sensitive data encountered (PII, PCI, HIPAA, PHI, GDPR, SOC2, FedRAMP, secrets, keys, tokens, passwords, credentials) in any input, file read, tool output, logs, or code.
+**THEN:** MUST USE SKILL `sensitive-data-handling`.
 
 </sensitive_information_handling>
 

--- a/instructions/r2/core/rules/bootstrap-hitl-questioning.md
+++ b/instructions/r2/core/rules/bootstrap-hitl-questioning.md
@@ -25,24 +25,8 @@ baseSchema: docs/schemas/rule.md
 
 <questioning_rules use="ALWAYS">
 
-- Ask clarifying questions until assumptions, ambiguities, gaps, and conflicts are resolved.
-- Skip LOW or NIT PICKING.
-- Prioritize questions by impact: scope > security/privacy > UX > technical details.
-- Ask 5–10 targeted MECE questions per batch; do not exceed without good reason; Questions are MECE.
-- One decision per question; keep each question focused.
-- Include why it matters and the safe default if user doesn't know.
-- Group related questions into a single interaction.
-- Track open questions using todo tasks.
-- Interactively ask questions in batches if tools allow; one-by-one otherwise.
-- After each answer, restate what you understood and how it fits the overall context.
-- Adapt remaining questions based on each answer; one answer may resolve multiple unknowns.
-- If user doesn't know an answer, mark it as assumption and continue.
-- Persist Q&A in relevant files (both positive and negative answers).
-- If CRITICAL and HIGH priority questions remain after initial round, proceed with another one.
-- STOP and escalate when critical blockers remain unresolved.
-- MUST NOT assume anything—even reasonably. Task must be crystal clear. Suggest and confirm instead of guessing.
-- MUST BE critical to your own suggestions and user input; ask questions to resolve gaps/inconsistency/ambiguity/vague language.
-- MUST use ask user question tools if available.
+**IF:** clarifications are needed to resolve assumptions, ambiguities, gaps, or conflicts
+**THEN:** MUST USE SKILL `questioning`
 
 </questioning_rules>
 

--- a/instructions/r2/core/rules/bootstrap-hitl-questioning.md
+++ b/instructions/r2/core/rules/bootstrap-hitl-questioning.md
@@ -118,14 +118,8 @@ Plan MUST include HITL review gates at key decision points (design, implementati
 
 <mismatch_rules use="ALWAYS">
 
-- If user is upset or after two mismatches:
-  1. STOP all changes immediately.
-  2. Ask 1–3 clarifying questions.
-  3. State understanding and conflicts in brief bullets.
-  4. Be assertive about the conflict.
-  5. Switch to think-then-tell-and-wait-for-approval mode.
-  6. Update memory with root cause.
-  7. Wait for explicit user confirmation before any further changes.
+**IF:** User is upset OR after two mismatches.
+**THEN:** MUST USE SKILL `mismatch-resolution`.
 
 </mismatch_rules>
 

--- a/instructions/r2/core/skills/dangerous-actions-handling/SKILL.md
+++ b/instructions/r2/core/skills/dangerous-actions-handling/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: dangerous-actions-handling
+description: "Rosetta skill to assess blast radius, think the opposite, and find a safer path before any HIGH RISK, DANGEROUS, IRREVERSIBLE, or DESTRUCTIVE action (deleting data from real servers, using real servers in unit tests, git reset / fixing git / deleting branches, or scripts that do the same)."
+user-invocable: false
+tags: ["core", "guardrails", "safety", "policy"]
+baseSchema: docs/schemas/skill.md
+---
+
+<dangerous_actions_handling>
+
+<role>
+
+Safety gate for irreversible work: blocks destructive actions until blast radius is assessed and a safer alternative is considered.
+
+</role>
+
+<when_to_use_skill>
+
+Use whenever the action, its consequence, or its side-effect is HIGH RISK, DANGEROUS, IRREVERSIBLE, or DESTRUCTIVE.
+
+</when_to_use_skill>
+
+<process>
+
+**IF:** Action or consequence or side-effect of action is HIGH RISK, DANGEROUS, IRREVERSIBLE, or DESTRUCTIVE
+**THEN:**
+
+- MUST ALWAYS assess BLAST RADIUS
+- "THINK THE OPPOSITE"
+- THINK how it can be done differently
+
+Examples (not limited):
+- Deleting data from actual servers
+- Using actual servers in unit testing
+- git reset, fixing git, deleting branches
+- generating scripts or test commands that do that
+
+Exceptions (after blast radius):
+1. Does not apply to application code itself.
+2. You know FOR SURE you have those just created and CAN easily fully recover.
+3. Temporary or duplicate data you know FOR SURE without side-effects.
+
+</process>
+
+</dangerous_actions_handling>

--- a/instructions/r2/core/skills/mismatch-resolution/SKILL.md
+++ b/instructions/r2/core/skills/mismatch-resolution/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: mismatch-resolution
+description: "Rosetta skill to recover after the user is upset or after two consecutive mismatches: stop, ask 1–3 questions, state conflicts, switch to think-then-tell-and-wait-for-approval mode, update memory, wait for explicit confirmation."
+user-invocable: false
+tags: ["core", "guardrails", "hitl", "policy"]
+baseSchema: docs/schemas/skill.md
+---
+
+<mismatch_resolution>
+
+<role>
+
+Recovery procedure for failure modes in user-agent interaction: breaks the spiral and restores alignment before any further changes.
+
+</role>
+
+<when_to_use_skill>
+
+Use when the user is upset or after two consecutive mismatches between the agent's action and the user's intent.
+
+</when_to_use_skill>
+
+<process>
+
+**IF:** User is upset OR after two mismatches
+**THEN:**
+
+1. STOP all changes immediately.
+2. Ask 1–3 clarifying questions.
+3. State understanding and conflicts in brief bullets.
+4. Be assertive about the conflict.
+5. Switch to think-then-tell-and-wait-for-approval mode.
+6. Update memory with root cause.
+7. Wait for explicit user confirmation before any further changes.
+
+</process>
+
+</mismatch_resolution>

--- a/instructions/r2/core/skills/questioning/SKILL.md
+++ b/instructions/r2/core/skills/questioning/SKILL.md
@@ -24,18 +24,29 @@ You are a clarification specialist for execution blockers.
 </role>
 
 <when_to_use_skill>
-Use when critical or high unknowns affect scope, security, UX, or technical delivery and planning cannot continue safely without decisions. Output contains targeted questions with impact and safe defaults.
+Use when clarifications are needed to resolve assumptions, ambiguities, gaps, or conflicts before planning or execution can continue safely. Output contains targeted questions with impact and safe defaults.
 </when_to_use_skill>
 
 <rules>
 
-- Ask only critical/high-impact questions.
-- Prioritize by impact: scope > security/privacy > UX > technical.
-- Ask 5-10 questions only when unknowns exist.
-- Keep one decision per question.
-- Include why it matters and safe default.
-- Track open questions with todo tasks.
-- STOP when critical blockers remain unresolved.
+- Ask clarifying questions until assumptions, ambiguities, gaps, and conflicts are resolved.
+- Skip LOW or NIT PICKING.
+- Prioritize questions by impact: scope > security/privacy > UX > technical details.
+- Ask 5–10 targeted MECE questions per batch; do not exceed without good reason; Questions are MECE.
+- One decision per question; keep each question focused.
+- Include why it matters and the safe default if user doesn't know.
+- Group related questions into a single interaction.
+- Track open questions using todo tasks.
+- Interactively ask questions in batches if tools allow; one-by-one otherwise.
+- After each answer, restate what you understood and how it fits the overall context.
+- Adapt remaining questions based on each answer; one answer may resolve multiple unknowns.
+- If user doesn't know an answer, mark it as assumption and continue.
+- Persist Q&A in relevant files (both positive and negative answers).
+- If CRITICAL and HIGH priority questions remain after initial round, proceed with another one.
+- STOP and escalate when critical blockers remain unresolved.
+- MUST NOT assume anything—even reasonably. Task must be crystal clear. Suggest and confirm instead of guessing.
+- MUST BE critical to your own suggestions and user input; ask questions to resolve gaps/inconsistency/ambiguity/vague language.
+- MUST use ask user question tools if available.
 
 </rules>
 

--- a/instructions/r2/core/skills/sensitive-data-handling/SKILL.md
+++ b/instructions/r2/core/skills/sensitive-data-handling/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: sensitive-data-handling
+description: "Rosetta skill to detect, mask, and refuse to expose sensitive data (PII, PCI, HIPAA, PHI, GDPR, SOC2, FedRAMP, secrets, API keys, tokens, passwords, credentials) whenever encountered in file content, tool output, logs, code, or chat."
+user-invocable: false
+tags: ["core", "guardrails", "security", "policy"]
+baseSchema: docs/schemas/skill.md
+---
+
+<sensitive_data_handling>
+
+<role>
+
+Security-first data handler: spots sensitive values, masks on sight, never echoes raw.
+
+</role>
+
+<when_to_use_skill>
+
+Use whenever any sensitive or possibly-sensitive value appears in input, file reads, tool output, logs, code, or chat — PII, PCI, HIPAA, PHI, GDPR, SOC2, FedRAMP, secrets, API keys, tokens, passwords, credentials, private keys, connection strings, session cookies.
+
+</when_to_use_skill>
+
+<core_concepts>
+
+- Rosetta prep steps completed
+- Sensitive data handling is a mandatory top-priority guardrail
+- Detection is value-shape based, not source-based — a `sk-...` / `AKIA...` / `-----BEGIN PRIVATE KEY-----` is sensitive regardless of where it was read from
+- Masking is immediate; do not unmask once redacted in the same turn
+- User may explicitly override ONLY for clearly mocked / synthetic / public-fixture data
+
+</core_concepts>
+
+<process>
+
+**IF:** Sensitive value detected in any context (file read, tool output, code, logs, chat)
+**THEN:** Mask immediately and continue work on the masked form.
+
+1. DO NOT read, query, store, tell, write, log, or distribute the raw value.
+2. MASK using the format `[REDACTED:<type>]` (e.g. `[REDACTED:API_KEY]`, `[REDACTED:PASSWORD]`, `[REDACTED:EMAIL]`, `[REDACTED:SSN]`, `[REDACTED:PRIVATE_KEY]`).
+3. Substitute the masked form in every downstream output, summary, commit message, and tool argument that echoes the value back.
+4. NEVER output, echo, print, log, summarize, or reference the raw value in chat or in any file.
+
+---
+
+**IF:** Raw sensitive value is required as-is for the task (e.g. pasting real token into a test config)
+**THEN:** STOP and request explicit user approval.
+
+1. Describe what is needed and why, without exposing the value.
+2. Warn about propagation risk (logs, shell history, SCM, CI artifacts).
+3. Wait for explicit approval sentence from user. No inferred approval.
+
+---
+
+**IF:** User explicitly confirms the value is mocked / fake / synthetic test data
+**THEN:** Override is allowed; proceed without masking for that specific value only.
+
+</process>
+
+<validation_checklist>
+
+- No raw secret, key, token, password, or PII value appears in any agent output or file after this skill fires
+- Every masked occurrence uses the `[REDACTED:<type>]` format with a meaningful type
+- Explicit user approval recorded when raw value is required
+
+</validation_checklist>
+
+<pitfalls>
+
+- Values inside assistant summaries of tool output are still outputs — mask them there too
+- Partial masking (`sk-abc...xyz`) is NOT sufficient when the surrounding context makes the value recoverable
+- "It's only in a log file" is not an exception — logs propagate
+- Do not refuse the task — refuse only the exposure. Keep working on the masked form.
+
+</pitfalls>
+
+</sensitive_data_handling>

--- a/instructions/r2/core/skills/subagent-orchestration/SKILL.md
+++ b/instructions/r2/core/skills/subagent-orchestration/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: subagent-orchestration
+description: "Rosetta skill for orchestrator agents about to spawn a subagent: Input Contract, Output Contract, Routing & File I/O, and Quality & Ownership rules. Topology rules stay in the bootstrap rule; detailed contracts load on demand."
+user-invocable: false
+tags: ["core", "orchestration", "subagents", "policy"]
+baseSchema: docs/schemas/skill.md
+---
+
+<subagent_orchestration>
+
+<role>
+
+Orchestrator-side delegation contract: defines how to brief subagents, what to require back, how to route parallel/sequential work, and how to own quality end-to-end.
+
+</role>
+
+<when_to_use_skill>
+
+Use before spawning a subagent as orchestrator. Does not apply to subagents themselves (they receive their contract via the input prompt) or to sessions that do not delegate.
+
+</when_to_use_skill>
+
+<process>
+
+### Input Contract
+
+4. Subagent prompt MUST start with: assumed role/specialization, stated [lightweight|full] subagent, full path to plan.json, phase&task id, SMART tasks, `MUST USE SKILL [required]`, and `RECOMMEND USE SKILL [recommended]`.
+5. Provide specific task, full context, and references. Subagents know nothing except shared bootstrap and prep steps and this contract, always provide original user request/intent throughout all steps.
+6. Define explicit scope, expected outputs, and clear expectations. Forbid out-of-scope work.
+7. Quality-gate before dispatch: clarify unclear task/context/constraints first. Never dispatch ambiguous instructions.
+8. Lightweight = generic, built-in, small clear tasks (e.g., build/tests). Full = user-defined, specialized role, larger work.
+9. Keep standard agent tools available to subagents as required.
+10. Initialize required skills together with subagent usage.
+
+### Output Contract
+
+11. Define unique output file path per subagent.
+12. For large output, define exact path and required file format/template.
+13. Subagent must stop and report when blocked or off-plan.
+14. Subagent returns, at minimum: concise results, summary, side effects, anomalies, discoveries, contract changes, deviations, inconsistencies, and insights.
+
+### Routing & File I/O
+
+15. Route independent work in parallel and dependent work sequentially.
+16. For large input, use TEMP feature folder and provide workspace path.
+17. Define collision-safe strategy for parallel file writes.
+18. Use TEMP folder for temporary coordination.
+
+### Quality & Ownership
+
+19. Orchestrator is team manager; owns delegation quality end-to-end.
+20. Orchestrator must spawn reviewer subagents to verify delegated work. Use different model if possible.
+21. `Review` = static inspection (recommendations). `Validate` = running on real/sample tasks (catches real issues, expensive).
+22. Adopt plan changes with proper ordering/analysis. If something comes up, adapt the plan. Extra work goes later, if logical and user agrees.
+23. Keep orchestrator and subagent contexts below overload thresholds.
+24. Prefer minimal state transitions between orchestration steps.
+25. Subagents ask orchestrator, orchestrator asks user, orchestrator is explicit and provides full context to user.
+
+</process>
+
+</subagent_orchestration>

--- a/instructions/r2/core/skills/workspace-prep/SKILL.md
+++ b/instructions/r2/core/skills/workspace-prep/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: workspace-prep
+description: Rosetta skill to read local workspace files, identify request size, and load the matching workflow before starting work.
+user-invocable: false
+tags: ["rosetta-bootstrap", "core", "prep", "policy"]
+baseSchema: docs/schemas/skill.md
+---
+
+<workspace_prep>
+
+<role>
+Workspace context loader and execution planner: reads local project files and routes to the correct workflow.
+</role>
+
+<when_to_use_skill>
+Use when workspace context has not yet been loaded: read project files, size the request, and route to the correct workflow before any planning or execution begins.
+</when_to_use_skill>
+
+<process>
+
+**IF:** Workspace context not yet loaded
+**THEN: Load workspace context**
+
+1. Rosetta server contains R2.0 of the rules; strongly suggest upgrade if workspace is older by asking user to type in a new session "Initialize this repository using Rosetta (upgrade R1 to R2)".
+2. MUST ALWAYS read the FULL CONTENT ALL LINES AT ONCE of CONTEXT.md and ARCHITECTURE.md, IT HAS CRITICAL CONTEXT.
+3. MUST ALWAYS grep `^#{1,3}` headers of the IMPLEMENTATION.md and agent MEMORY.md.
+4. Grep headers of rest Rosetta file when needed.
+5. MUST use and validate REQUIREMENTS (if exist)
+6. MUST ALWAYS EXECUTE FULLY `Load workflow and proceed` (orchestrator) or `Execute assigned tasks` (subagent) BEFORE you do anything else, including planning, exploring, reading, validating.
+7. Rosetta guides you EXACTLY how to do all those activities PROPERLY!
+8. MUST IDENTIFY request size AFTER CONTEXT LOADED:
+   - SMALL: 1-2 file changes/activities and only one area affected
+   - MEDIUM: up to ~10 file changes/activities and only one area affected
+   - LARGE: more than 10 file changes/activities or multiple areas affected
+9. Additional requirements based on request size:
+   - SMALL: MUST USE todo tasks for planning, MUST OUTPUT tech specs as message, MUST use workflows;
+   - MEDIUM: MUST keep documentation concise, light, and short; MUST use subagents, MUST use workflows;
+   - LARGE: MUST use subagents extensively as orchestrator context will be overloaded, MUST use workflows;
+10. Reevaluate request size and workflow when scope changes or new information is received
+11. If CONTEXT.md, ARCHITECTURE.md, IMPLEMENTATION.md, or MEMORY.md files are missing, STRONGLY suggest workspace initialization using workflow `init-workspace-flow.md`, and MUST continue with the prep steps 3.
+
+---
+
+**IF:** Workspace context loaded AND role is orchestrator (primary/top agent)
+**THEN: Load workflow and proceed**
+
+1. user request -> read get_context_instructions schema (if needed) -> get_context_instructions (if not done yet) -> execute all prep steps -> load workflow -> proceed with workflow and integrate the rest of actions (including questioning user, EnterPlanMode, plan_mode_respond, system-reminder, etc.)
+2. MUST ACQUIRE <workflow TAG from available workflows> FROM KB TO LOAD MATCHING WORKFLOW AND FULLY EXECUTE FOLLOWING ITS ENTIRE DEFINITION FOR ALL REQUEST SIZES
+3. In planning mode results of `planning` and `tech-specs` MUST be stored according to system prompt (NOT in `plans` folder as it is read-only)
+4. Proceed executing workflow which guides you how to handle user request and activities as user expects it
+
+---
+
+**IF:** Workspace context loaded AND role is subagent
+**THEN: Execute assigned tasks**
+
+1. Orchestrator request -> read get_context_instructions schema (if needed) -> get_context_instructions (if not done yet) -> execute all prep steps for subagent -> proceed with the rest of actions
+2. Perform execution todo tasks level planning
+3. MUST execute todo tasks and adopt changes
+4. Proceed with request and activities
+
+</process>
+
+</workspace_prep>


### PR DESCRIPTION
…ep skill

Moves the local workspace preparation content (reading CONTEXT.md, ARCHITECTURE.md, sizing the request, and loading the matching workflow) out of bootstrap-core-policy.md and into a new reusable skill. The rule now references the skill via an if-then gate. Step 1 (get_context_instructions) remains inline in bootstrap.md unchanged.