### PR TITLE
Add PDB and probe support to MCP Helm chart

### DIFF
--- a/helm-charts/rosetta-mcp-server/Chart.yaml
+++ b/helm-charts/rosetta-mcp-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rosetta-mcp-helm-chart
 description: Helm chart for Rosetta MCP server - the consulting layer between IDEs and Rosetta knowledge base (RAGFlow)
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "2.0.0"
 keywords:
   - rosetta

--- a/helm-charts/rosetta-mcp-server/templates/deployment.yaml
+++ b/helm-charts/rosetta-mcp-server/templates/deployment.yaml
@@ -48,6 +48,18 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.env.enabled }}
           env:
             {{- if .Values.env.vars }}

--- a/helm-charts/rosetta-mcp-server/templates/poddisruptionbudget.yaml
+++ b/helm-charts/rosetta-mcp-server/templates/poddisruptionbudget.yaml
@@ -1,0 +1,20 @@
+{{- $replicas := ternary .Values.autoscaling.minReplicas .Values.replicaCount .Values.autoscaling.enabled -}}
+{{- if and .Values.podDisruptionBudget.enabled (gt (int $replicas) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "rosetta-mcp.fullname" . }}-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rosetta-mcp.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "rosetta-mcp.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm-charts/rosetta-mcp-server/templates/poddisruptionbudget.yaml
+++ b/helm-charts/rosetta-mcp-server/templates/poddisruptionbudget.yaml
@@ -8,10 +8,12 @@ metadata:
   labels:
     {{- include "rosetta-mcp.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- if and (ne .Values.podDisruptionBudget.minAvailable nil) (ne .Values.podDisruptionBudget.maxUnavailable nil) }}
+  {{- fail "podDisruptionBudget: set only one of minAvailable or maxUnavailable" }}
   {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  {{- if ne .Values.podDisruptionBudget.minAvailable nil }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if ne .Values.podDisruptionBudget.maxUnavailable nil }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
   selector:

--- a/helm-charts/rosetta-mcp-server/values.yaml
+++ b/helm-charts/rosetta-mcp-server/values.yaml
@@ -3,6 +3,17 @@ fullnameOverride: ""
 
 replicaCount: 1
 
+# Health probes (optional)
+# livenessProbe: {}
+# readinessProbe: {}
+# startupProbe: {}
+
+# PodDisruptionBudget — enable when replicaCount > 1 (or autoscaling minReplicas > 1)
+podDisruptionBudget:
+  enabled: false
+  maxUnavailable: 1
+  # minAvailable: 1
+
 image:
   repository: griddynamics/rosetta-mcp
   # Uncomment and set the image tag. Defaults to .Chart.AppVersion if not set:

--- a/helm-charts/rosetta-mcp-server/values.yaml
+++ b/helm-charts/rosetta-mcp-server/values.yaml
@@ -4,9 +4,29 @@ fullnameOverride: ""
 replicaCount: 1
 
 # Health probes (optional)
-# livenessProbe: {}
-# readinessProbe: {}
-# startupProbe: {}
+# Example (edit as needed):
+# livenessProbe:
+#   tcpSocket:
+#     port: port8000
+#   periodSeconds: 30
+#   timeoutSeconds: 5
+#   failureThreshold: 3
+
+# readinessProbe:
+#   httpGet:
+#     path: /healthz
+#     port: port8000
+#   periodSeconds: 10
+#   timeoutSeconds: 5
+#   failureThreshold: 3
+
+# startupProbe:
+#   httpGet:
+#     path: /healthz
+#     port: port8000
+#   periodSeconds: 10
+#   timeoutSeconds: 5
+#   failureThreshold: 40
 
 # PodDisruptionBudget — enable when replicaCount > 1 (or autoscaling minReplicas > 1)
 podDisruptionBudget:


### PR DESCRIPTION
# Add PDB and startup/readiness/liveness probes support to MCP Helm chart

This PR extends the `rosetta-mcp-server` Helm chart to support configurable Kubernetes health probes on the Deployment and an optional PodDisruptionBudget (PDB), and bumps the chart version to reflect the new functionality.

**Changes:**
- Add optional `livenessProbe`, `readinessProbe`, and `startupProbe` values and render them into the Deployment when configured.
- Add an optional PodDisruptionBudget template controlled by `podDisruptionBudget.*` values (and gated by replica/minReplica count).
- Bump chart version from `0.2.0` to `0.3.0`.