### PR TITLE
Migrate SDLC references in gain.json to public GitHub services

### DIFF
--- a/gain.json
+++ b/gain.json
@@ -10,6 +10,12 @@
     "copilot"
   ],
   "sdlc": {
+    "issue_tracker": "GitHub Issues",
+    "issue_tracker_project": "https://github.com/griddynamics/rosetta/issues",
+    "wiki": "GitHub Wiki",
+    "wiki_project": "https://github.com/griddynamics/rosetta/wiki",
+    "test_management": "TestRail",
+    "test_management_project": "CTORNDGAIN",
     "scm": "GitHub",
     "scm_project": "https://github.com/griddynamics/rosetta",
     "build_management": "Github Actions",

--- a/gain.json
+++ b/gain.json
@@ -10,12 +10,6 @@
     "copilot"
   ],
   "sdlc": {
-    "issue_tracker": "Jira",
-    "issue_tracker_project": "https://griddynamics.atlassian.net/jira/software/c/projects/CTORNDGAIN/boards/6077",
-    "wiki": "Confluence",
-    "wiki_project": "https://griddynamics.atlassian.net/wiki/spaces/RNDM/pages/3927834626/Rosetta+Knowledge+Base",
-    "test_management": "TestRail",
-    "test_management_project": "CTORNDGAIN",
     "scm": "GitHub",
     "scm_project": "https://github.com/griddynamics/rosetta",
     "build_management": "Github Actions",


### PR DESCRIPTION
## Summary

Addresses **SEC-301: Internal project metadata exposed in gain.json**.

Per review feedback (this is a public repo, so SDLC pointers should target public services rather than be removed), the internal references in the `sdlc` block are migrated to their public GitHub equivalents instead of being deleted:

- `issue_tracker`: `Jira` → `GitHub Issues` (`https://github.com/griddynamics/rosetta/issues`)
- `wiki`: `Confluence` → `GitHub Wiki` (`https://github.com/griddynamics/rosetta/wiki`)

## Notes

- `test_management` is intentionally left as `TestRail` / `CTORNDGAIN` for now — GitHub has no native test-management equivalent. This remains an internal reference and can be revisited in a follow-up.
- Remaining `*_project` fields reference only public GitHub URLs or generic placeholders (`ROSETTA`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)