### PR TITLE
docs: improve README and website with structured developer-facing content covering useful workflows and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,37 @@ Rosetta-guided work follows five phases — **Prepare → Research → Plan → 
 > [!NOTE]
 > If you are effectively using your current setup, writing your own skills, and managing AI using your own processes, you probably don't need Rosetta.
 
+## [Top Workflows](USAGE_GUIDE.md#workflows)
+
+1. `coding-flow`: AI creates features, fixes defects, and performs refactoring, everything end-to-end. AI performs discovery, design, specs and a plan, user review, then AI implements and runs separate review and validation passes (including running application). Most useful for medium to large coding tasks, and for controlled component-by-component migration/modernization work.
+2. `requirements-authoring-flow`: AI works with user and raw artifacts to define entire-application requirements. AI discovers context and existing constraints, captures intent, drafts atomic requirement units, validates them, and finalizes traceability artifacts. This is the most efficient use of coding agents. Requirements then Coding.
+3. `testgen-flow`, `api-aqa-flow`, `ui-aqa-flow`: AI handles QA-related work such as generating test cases and creating API or UI automation tests. AI first collects project context, requirements, and existing QA assets, clarifies gaps, and only after that generates test cases or automation tests.
+4. `code-analysis-flow`: AI creates grounded analysis documents based on the codebase. AI first loads project context, asks clarification questions, then produces either one focused analysis document or parallel module analyses plus a summary.
+5. `help-flow`: AI explains available Rosetta workflows, skills, and agents. Most useful when the user is unsure which Rosetta capability to use.
+6. `init-workspace-flow`: AI sets up a repository for AI use in both brownfield and greenfield projects. AI first analyzes the workspace, builds baseline docs, asks gap-filling questions, and verifies the result. Use it once per repository as its purpose is to build context for subsequent sessions.
+
+If you prefer more vibe-coding, check the guardrails and useful skills below.
+
+## Top Guardrails
+
+1. Dangerous actions detection and handling: AI will think about blast radius and will not take unsafe actions without clear acceptance from a user.
+2. Sensitive data handling (Secrets, PCI, PHI, PII, etc): AI will not read, query, or distribute (affects itself), and it will code respecting that (affects code).
+3. Shared infrastructure understanding: AI will not behave as if the environment belongs only to it.
+4. Deviation control: AI will detect drift and will try to overcome that.
+5. Human-in-the-Loop: AI will ask for user review or approval whenever it is needed.
+6. Risk assessment: AI will review current workspace setup, if there is a chance AI can damage - it will report.
+7. Self-learning and organization: AI learns on mistakes (repo-level) and organizes its own work.
+
+## [Top Skills](USAGE_GUIDE.md)
+
+1. `planning`, `tech-specs`: Turn a request into a clear plan and actionable specs.
+2. `orchestration`: Coordinate an efficient team of subagents for large tasks (also request "team manager" capability for full experience).
+3. `questioning`, `hitl`: AI to work with human, not over or behind, to be more human-oriented.
+4. `research`, `reverse-engineering`: Repository grounded research and logical reverse engineering (business logic extraction).
+5. `coding`, `debugging`, `testing`: Implementation, debugging with root-cause analysis, and validation.
+6. `reasoning`: Requires AI to decompose and recompose the problem, boundaries, actors, roles, gaps, contradictions, and perform recursive tree-of-thoughts reasoning.
+7. `solr-*`: AI will help to build SOLR search-related artifacts.
+
 ## Without Rosetta / With Rosetta
 
 | Without Rosetta                                  | With Rosetta                                  |
@@ -108,34 +139,6 @@ Higher layers propagate to every project automatically; teams customize without 
 
 https://github.com/user-attachments/assets/fc0ef06a-2f9c-49fa-bc05-68001dadd286
 
-## Workflows
-
-1. `coding-flow`: AI creates features, fixes defects, and performs refactoring. AI first starts with deep discovery and design, produces specs and a plan, requires explicit approval before implementation, then runs separate review and validation passes. Most useful for medium to large coding tasks, and for controlled component-by-component migration/modernization work.
-2. `requirements-authoring-flow`: AI works with raw artifacts to define entire-application requirements or large feature requirements. AI first discovers context and existing constraints, then captures intent, approves structure, drafts atomic requirement units, validates them, and finalizes traceability artifacts. Most useful when requirements shoud be created to be the source of truth for later development. Tip: The most efficient use of coding agents.
-3. `testgen-flow`, `api-aqa-flow`, `ui-aqa-flow`: AI handles QA-related work such as generating test cases and creating API or UI automation tests. AI first collects project context, requirements, and existing QA assets, clarifies gaps, and only after it generate test cases or automation tests. 
-4. `code-analysis-flow` AI creates grounded analysis documents based on the codebase. AI first loads project context, asks clarification questions, then produces either one focused analysis document or parallel module analyses plus a summary. 
-5. `help-flow` AI explains available Rosetta workflows, skills, and agents. Most useful when the user is unsure which Rosetta capability to use.
-6. `init-workspace-flow`: AI sets up a repository for AI use in both brownfield and greenfield projects. AI first analyzes the workspace, builds baseline docs, asks gap-filling questions, and verifies the result. Use it once per repository.
-
-If you prefer more vibe-coding, check the guardrails and usefult skills bellow.
-
-## Guardrails
-
-1. Dangerous actions detection and handling: AI will not perform unsafe actions (e.g `git reset`) without clear acceptance from a user.
-2. Sensitive data handling: AI will not read secrets.
-3. Shared infrastructure understanding: AI will not behave as if the environment belongs only to it.
-4. Deviation control: AI will not drift away from the task.
-5. Human-in-the-Loop: AI will ask for user review or approval is needed.
-6. Risk assessment: AI will not ignore risks of planned action.
-7. Self-learning and organization: AI will not lose important context.
-
-## Skills
-
-1. `planning`, `tech-specs`: AI uses to turn a request into a clear plan and actionable specs.
-2. `orchestration`: AI uses to coordinate a team of subagents for large tasks.
-3. `questioning`, `hitl`: AI uses to be more human-oriented by asking questions and pausing for review.
-4. `research`, `reverse-engineering`: AI uses to investigate existing systems before acting.
-5. `coding`, `debugging`, `testing`: AI uses for implementation, root-cause analysis, and validation.
 
 ## Why not just use IDE rules?
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ Higher layers propagate to every project automatically; teams customize without 
 
 https://github.com/user-attachments/assets/fc0ef06a-2f9c-49fa-bc05-68001dadd286
 
+## Top-5 Common Situations Where Rosetta Helps
+
+- **AI keeps making assumptions and goes too far before checking with you**
+  -> use `hitl` skill 
+  -> the AI asks questions early, stays aligned during the task, and avoids costly rework later
+
+- **AI suggests fixes, but does not really debug the problem**
+  -> use `debugging` skill
+  -> the AI focuses on evidence, reproduction, and root cause instead of symptom-only patches
+
+- **The task is too large or too complex for one AI agent to handle reliably**
+  -> use `orchestration` skill
+  -> the AI can delegate work, then review, verify, and reconcile subagent results instead of trusting them blindly
+
+- **You want more than “generate code and hope”**
+  -> use `coding-flow` workflow
+  -> it adds the parts AI agents usually skips: context first, design before code, approval gates, fresh-context review, and real validation
+
+- **You need to modernize, migrate, or upgrade code without breaking what already works**
+  -> use `modernization-flow` workflow
+  -> AI agents often struggle with modernization because they rewrite too early and miss cross-project dependencies. This workflow makes them analyze first, map the current system to the target state, and implement in controlled phases
+
+Explore more Rosetta workflows and skills in [USAGE_GUIDE.md](USAGE_GUIDE.md).
+
 ## Why not just use IDE rules?
 
 IDE rules (`.cursorrules`, `CLAUDE.md`, Copilot custom instructions) are useful, but they are usually local to one tool, one repo, or one developer. Rosetta makes instructions layered, versioned, reusable, and portable across agents and IDEs — organization standards flow into every project, while project-specific context stays local and customizable. On top of that, Rosetta adds the workflows, guardrails, and approval gates that flat rules files do not provide.

--- a/README.md
+++ b/README.md
@@ -108,44 +108,38 @@ Higher layers propagate to every project automatically; teams customize without 
 
 https://github.com/user-attachments/assets/fc0ef06a-2f9c-49fa-bc05-68001dadd286
 
-## Top-5 Common Situations Where Rosetta Helps
+## Workflows
 
-- **AI keeps making assumptions and goes too far before checking with you**
-  -> use `hitl` skill 
-  -> the AI asks questions early, stays aligned during the task, and avoids costly rework later
+1. `coding-flow`: AI creates features, fixes defects, and performs refactoring. AI first starts with deep discovery and design, produces specs and a plan, requires explicit approval before implementation, then runs separate review and validation passes. Most useful for medium to large coding tasks, and for controlled component-by-component migration/modernization work.
+2. `requirements-authoring-flow`: AI works with raw artifacts to define entire-application requirements or large feature requirements. AI first discovers context and existing constraints, then captures intent, approves structure, drafts atomic requirement units, validates them, and finalizes traceability artifacts. Most useful when requirements shoud be created to be the source of truth for later development. Tip: The most efficient use of coding agents.
+3. `testgen-flow`, `api-aqa-flow`, `ui-aqa-flow`: AI handles QA-related work such as generating test cases and creating API or UI automation tests. AI first collects project context, requirements, and existing QA assets, clarifies gaps, and only after it generate test cases or automation tests. 
+4. `code-analysis-flow` AI creates grounded analysis documents based on the codebase. AI first loads project context, asks clarification questions, then produces either one focused analysis document or parallel module analyses plus a summary. 
+5. `help-flow` AI explains available Rosetta workflows, skills, and agents. Most useful when the user is unsure which Rosetta capability to use.
+6. `init-workspace-flow`: AI sets up a repository for AI use in both brownfield and greenfield projects. AI first analyzes the workspace, builds baseline docs, asks gap-filling questions, and verifies the result. Use it once per repository.
 
-- **AI suggests fixes, but does not really debug the problem**
-  -> use `debugging` skill
-  -> the AI focuses on evidence, reproduction, and root cause instead of symptom-only patches
+If you prefer more vibe-coding, check the guardrails and usefult skills bellow.
 
-- **The task is too large or too complex for one AI agent to handle reliably**
-  -> use `orchestration` skill
-  -> the AI can delegate work, then review, verify, and reconcile subagent results instead of trusting them blindly
+## Guardrails
 
-- **You want more than “generate code and hope”**
-  -> use `coding-flow` workflow
-  -> it adds the parts AI agents usually skips: context first, design before code, approval gates, fresh-context review, and real validation
+1. Dangerous actions detection and handling: AI will not perform unsafe actions (e.g `git reset`) without clear acceptance from a user.
+2. Sensitive data handling: AI will not read secrets.
+3. Shared infrastructure understanding: AI will not behave as if the environment belongs only to it.
+4. Deviation control: AI will not drift away from the task.
+5. Human-in-the-Loop: AI will ask for user review or approval is needed.
+6. Risk assessment: AI will not ignore risks of planned action.
+7. Self-learning and organization: AI will not lose important context.
 
-- **You need to modernize, migrate, or upgrade code without breaking what already works**
-  -> use `modernization-flow` workflow
-  -> AI agents often struggle with modernization because they rewrite too early and miss cross-project dependencies. This workflow makes them analyze first, map the current system to the target state, and implement in controlled phases
+## Skills
 
-Explore more Rosetta workflows and skills in [USAGE_GUIDE.md](USAGE_GUIDE.md).
+1. `planning`, `tech-specs`: AI uses to turn a request into a clear plan and actionable specs.
+2. `orchestration`: AI uses to coordinate a team of subagents for large tasks.
+3. `questioning`, `hitl`: AI uses to be more human-oriented by asking questions and pausing for review.
+4. `research`, `reverse-engineering`: AI uses to investigate existing systems before acting.
+5. `coding`, `debugging`, `testing`: AI uses for implementation, root-cause analysis, and validation.
 
 ## Why not just use IDE rules?
 
 IDE rules (`.cursorrules`, `CLAUDE.md`, Copilot custom instructions) are useful, but they are usually local to one tool, one repo, or one developer. Rosetta makes instructions layered, versioned, reusable, and portable across agents and IDEs — organization standards flow into every project, while project-specific context stays local and customizable. On top of that, Rosetta adds the workflows, guardrails, and approval gates that flat rules files do not provide.
-
-## Why use it
-
-| For builders | For organizations |
-| --- | --- |
-| **Deep project context** — reads your architecture and conventions, not a few open files | **One standard** across every team, tool, model, and repo |
-| **Plain-language tasks** — a slash command, no prompt scaffolding or new syntax | **No vendor lock-in** — one instruction set across Claude Code, Cursor, Copilot, Codex; engineers keep their IDEs |
-| **Ready-made flows** — coding, testing, AQA, research, and more | **Versioned control** — review, approve, and roll back instructions in Git |
-| **Plans and approval gates** before code, not after the damage | **Knowledge captured once** — out of senior engineers' heads |
-| **Fresh-context review** and execution-backed validation | **Cross-project intelligence** _(opt-in)_ — agents see the system, not just one repo |
-| **Less babysitting** — fewer wrong turns to catch and re-prompt | **Runs inside your perimeter** — works with limited internet access; no source code leaves |
 
 See [how Rosetta fits your workflow](OVERVIEW.md#how-rosetta-fits-into-your-workflow) and [how it protects you](USAGE_GUIDE.md#how-rosetta-protects-you).
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ If you prefer more vibe-coding, check the guardrails and usefult skills bellow.
 
 IDE rules (`.cursorrules`, `CLAUDE.md`, Copilot custom instructions) are useful, but they are usually local to one tool, one repo, or one developer. Rosetta makes instructions layered, versioned, reusable, and portable across agents and IDEs — organization standards flow into every project, while project-specific context stays local and customizable. On top of that, Rosetta adds the workflows, guardrails, and approval gates that flat rules files do not provide.
 
+## Why use it
+
+| For builders | For organizations |
+| --- | --- |
+| **Deep project context** — reads your architecture and conventions, not a few open files | **One standard** across every team, tool, model, and repo |
+| **Plain-language tasks** — a slash command, no prompt scaffolding or new syntax | **No vendor lock-in** — one instruction set across Claude Code, Cursor, Copilot, Codex; engineers keep their IDEs |
+| **Ready-made flows** — coding, testing, AQA, research, and more | **Versioned control** — review, approve, and roll back instructions in Git |
+| **Plans and approval gates** before code, not after the damage | **Knowledge captured once** — out of senior engineers' heads |
+| **Fresh-context review** and execution-backed validation | **Cross-project intelligence** _(opt-in)_ — agents see the system, not just one repo |
+| **Less babysitting** — fewer wrong turns to catch and re-prompt | **Runs inside your perimeter** — works with limited internet access; no source code leaves |
+
 See [how Rosetta fits your workflow](OVERVIEW.md#how-rosetta-fits-into-your-workflow) and [how it protects you](USAGE_GUIDE.md#how-rosetta-protects-you).
 
 <details>

--- a/docs/web/docs/introduction.md
+++ b/docs/web/docs/introduction.md
@@ -30,6 +30,37 @@ permalink: /docs/introduction/
 
 Rosetta-guided work follows five phases: **Prepare** (load guardrails and context), **Research** (gather relevant knowledge), **Plan** (produce a reviewable plan), **Act** (execute with full context), and **Validate** (verify with real execution evidence). Read more in the [Usage Guide](/rosetta/docs/usage-guide/#workflows).
 
+## [Top Workflows](/rosetta/docs/usage-guide/#workflows)
+
+1. `coding-flow`: AI creates features, fixes defects, and performs refactoring, everything end-to-end. AI performs discovery, design, specs and a plan, user review, then AI implements and runs separate review and validation passes (including running application). Most useful for medium to large coding tasks, and for controlled component-by-component migration/modernization work.
+2. `requirements-authoring-flow`: AI works with user and raw artifacts to define entire-application requirements. AI discovers context and existing constraints, captures intent, drafts atomic requirement units, validates them, and finalizes traceability artifacts. This is the most efficient use of coding agents. Requirements then Coding.
+3. `testgen-flow`, `api-aqa-flow`, `ui-aqa-flow`: AI handles QA-related work such as generating test cases and creating API or UI automation tests. AI first collects project context, requirements, and existing QA assets, clarifies gaps, and only after that generates test cases or automation tests.
+4. `code-analysis-flow`: AI creates grounded analysis documents based on the codebase. AI first loads project context, asks clarification questions, then produces either one focused analysis document or parallel module analyses plus a summary.
+5. `help-flow`: AI explains available Rosetta workflows, skills, and agents. Most useful when the user is unsure which Rosetta capability to use.
+6. `init-workspace-flow`: AI sets up a repository for AI use in both brownfield and greenfield projects. AI first analyzes the workspace, builds baseline docs, asks gap-filling questions, and verifies the result. Use it once per repository as its purpose is to build context for subsequent sessions.
+
+If you prefer more vibe-coding, check the guardrails and useful skills below.
+
+## Top Guardrails
+
+1. Dangerous actions detection and handling: AI will think about blast radius and will not take unsafe actions without clear acceptance from a user.
+2. Sensitive data handling (Secrets, PCI, PHI, PII, etc): AI will not read, query, or distribute (affects itself), and it will code respecting that (affects code).
+3. Shared infrastructure understanding: AI will not behave as if the environment belongs only to it.
+4. Deviation control: AI will detect drift and will try to overcome that.
+5. Human-in-the-Loop: AI will ask for user review or approval whenever it is needed.
+6. Risk assessment: AI will review current workspace setup, if there is a chance AI can damage - it will report.
+7. Self-learning and organization: AI learns on mistakes (repo-level) and organizes its own work.
+
+## [Top Skills](/rosetta/docs/usage-guide/)
+
+1. `planning`, `tech-specs`: Turn a request into a clear plan and actionable specs.
+2. `orchestration`: Coordinate an efficient team of subagents for large tasks (also request "team manager" capability for full experience).
+3. `questioning`, `hitl`: AI to work with human, not over or behind, to be more human-oriented.
+4. `research`, `reverse-engineering`: Repository grounded research and logical reverse engineering (business logic extraction).
+5. `coding`, `debugging`, `testing`: Implementation, debugging with root-cause analysis, and validation.
+6. `reasoning`: Requires AI to decompose and recompose the problem, boundaries, actors, roles, gaps, contradictions, and perform recursive tree-of-thoughts reasoning.
+7. `solr-*`: AI will help to build SOLR search-related artifacts.
+
 ## Why use it
 
 - **Context engineering, not prompt hacking.** Agents receive your conventions, architecture, and business rules automatically — structured, versioned, and ready before the first line of code. See [how it fits your workflow](/rosetta/docs/overview/#how-rosetta-fits-into-your-workflow).
@@ -86,35 +117,6 @@ STDIO transport is available for environments with limited internet access. [All
 ## Tech Demo
 
 <video src="https://github.com/user-attachments/assets/fc0ef06a-2f9c-49fa-bc05-68001dadd286" controls width="100%"></video>
-
-## Workflows
-
-1. `coding-flow`: AI creates features, fixes defects, and performs refactoring. AI first starts with deep discovery and design, produces specs and a plan, requires explicit approval before implementation, then runs separate review and validation passes. Most useful for medium to large coding tasks, and for controlled component-by-component migration/modernization work.
-2. `requirements-authoring-flow`: AI works with raw artifacts to define entire-application requirements or large feature requirements. AI first discovers context and existing constraints, then captures intent, approves structure, drafts atomic requirement units, validates them, and finalizes traceability artifacts. Most useful when requirements shoud be created to be the source of truth for later development. Tip: The most efficient use of coding agents.
-3. `testgen-flow`, `api-aqa-flow`, `ui-aqa-flow`: AI handles QA-related work such as generating test cases and creating API or UI automation tests. AI first collects project context, requirements, and existing QA assets, clarifies gaps, and only after it generate test cases or automation tests. 
-4. `code-analysis-flow` AI creates grounded analysis documents based on the codebase. AI first loads project context, asks clarification questions, then produces either one focused analysis document or parallel module analyses plus a summary. 
-5. `help-flow` AI explains available Rosetta workflows, skills, and agents. Most useful when the user is unsure which Rosetta capability to use.
-6. `init-workspace-flow`: AI sets up a repository for AI use in both brownfield and greenfield projects. AI first analyzes the workspace, builds baseline docs, asks gap-filling questions, and verifies the result. Use it once per repository.
-
-If you prefer more vibe-coding, check the guardrails and usefult skills bellow.
-
-## Guardrails
-
-1. Dangerous actions detection and handling: AI will not perform unsafe actions (e.g `git reset`) without clear acceptance from a user.
-2. Sensitive data handling: AI will not read secrets.
-3. Shared infrastructure understanding: AI will not behave as if the environment belongs only to it.
-4. Deviation control: AI will not drift away from the task.
-5. Human-in-the-Loop: AI will ask for user review or approval is needed.
-6. Risk assessment: AI will not ignore risks of planned action.
-7. Self-learning and organization: AI will not lose important context.
-
-## Skills
-
-1. `planning`, `tech-specs`: AI uses to turn a request into a clear plan and actionable specs.
-2. `orchestration`: AI uses to coordinate a team of subagents for large tasks.
-3. `questioning`, `hitl`: AI uses to be more human-oriented by asking questions and pausing for review.
-4. `research`, `reverse-engineering`: AI uses to investigate existing systems before acting.
-5. `coding`, `debugging`, `testing`: AI uses for implementation, root-cause analysis, and validation.
 
 ## Supported IDEs and Agents
 

--- a/docs/web/docs/introduction.md
+++ b/docs/web/docs/introduction.md
@@ -87,6 +87,30 @@ STDIO transport is available for environments with limited internet access. [All
 
 <video src="https://github.com/user-attachments/assets/fc0ef06a-2f9c-49fa-bc05-68001dadd286" controls width="100%"></video>
 
+## Top-5 Common Situations Where Rosetta Helps
+
+- **AI keeps making assumptions and goes too far before checking with you**
+  -> use `hitl` skill
+  -> the AI asks questions early, stays aligned during the task, and avoids costly rework later
+
+- **AI suggests fixes, but does not really debug the problem**
+  -> use `debugging` skill
+  -> the AI focuses on evidence, reproduction, and root cause instead of symptom-only patches
+
+- **The task is too large or too complex for one AI agent to handle reliably**
+  -> use `orchestration` skill
+  -> the AI can delegate work, then review, verify, and reconcile subagent results instead of trusting them blindly
+
+- **You want more than “generate code and hope”**
+  -> use `coding-flow` workflow
+  -> it adds the parts AI agents usually skip: context first, design before code, approval gates, fresh-context review, and real validation
+
+- **You need to modernize, migrate, or upgrade code without breaking what already works**
+  -> use `modernization-flow` workflow
+  -> AI agents often struggle with modernization because they rewrite too early and miss cross-project dependencies. This workflow makes them analyze first, map the current system to the target state, and implement in controlled phases
+
+Explore more Rosetta workflows and skills in the [Usage Guide](/rosetta/docs/usage-guide/).
+
 ## Supported IDEs and Agents
 
 - Cursor

--- a/docs/web/docs/introduction.md
+++ b/docs/web/docs/introduction.md
@@ -87,29 +87,34 @@ STDIO transport is available for environments with limited internet access. [All
 
 <video src="https://github.com/user-attachments/assets/fc0ef06a-2f9c-49fa-bc05-68001dadd286" controls width="100%"></video>
 
-## Top-5 Common Situations Where Rosetta Helps
+## Workflows
 
-- **AI keeps making assumptions and goes too far before checking with you**
-  -> use `hitl` skill
-  -> the AI asks questions early, stays aligned during the task, and avoids costly rework later
+1. `coding-flow`: AI creates features, fixes defects, and performs refactoring. AI first starts with deep discovery and design, produces specs and a plan, requires explicit approval before implementation, then runs separate review and validation passes. Most useful for medium to large coding tasks, and for controlled component-by-component migration/modernization work.
+2. `requirements-authoring-flow`: AI works with raw artifacts to define entire-application requirements or large feature requirements. AI first discovers context and existing constraints, then captures intent, approves structure, drafts atomic requirement units, validates them, and finalizes traceability artifacts. Most useful when requirements shoud be created to be the source of truth for later development. Tip: The most efficient use of coding agents.
+3. `testgen-flow`, `api-aqa-flow`, `ui-aqa-flow`: AI handles QA-related work such as generating test cases and creating API or UI automation tests. AI first collects project context, requirements, and existing QA assets, clarifies gaps, and only after it generate test cases or automation tests. 
+4. `code-analysis-flow` AI creates grounded analysis documents based on the codebase. AI first loads project context, asks clarification questions, then produces either one focused analysis document or parallel module analyses plus a summary. 
+5. `help-flow` AI explains available Rosetta workflows, skills, and agents. Most useful when the user is unsure which Rosetta capability to use.
+6. `init-workspace-flow`: AI sets up a repository for AI use in both brownfield and greenfield projects. AI first analyzes the workspace, builds baseline docs, asks gap-filling questions, and verifies the result. Use it once per repository.
 
-- **AI suggests fixes, but does not really debug the problem**
-  -> use `debugging` skill
-  -> the AI focuses on evidence, reproduction, and root cause instead of symptom-only patches
+If you prefer more vibe-coding, check the guardrails and usefult skills bellow.
 
-- **The task is too large or too complex for one AI agent to handle reliably**
-  -> use `orchestration` skill
-  -> the AI can delegate work, then review, verify, and reconcile subagent results instead of trusting them blindly
+## Guardrails
 
-- **You want more than “generate code and hope”**
-  -> use `coding-flow` workflow
-  -> it adds the parts AI agents usually skip: context first, design before code, approval gates, fresh-context review, and real validation
+1. Dangerous actions detection and handling: AI will not perform unsafe actions (e.g `git reset`) without clear acceptance from a user.
+2. Sensitive data handling: AI will not read secrets.
+3. Shared infrastructure understanding: AI will not behave as if the environment belongs only to it.
+4. Deviation control: AI will not drift away from the task.
+5. Human-in-the-Loop: AI will ask for user review or approval is needed.
+6. Risk assessment: AI will not ignore risks of planned action.
+7. Self-learning and organization: AI will not lose important context.
 
-- **You need to modernize, migrate, or upgrade code without breaking what already works**
-  -> use `modernization-flow` workflow
-  -> AI agents often struggle with modernization because they rewrite too early and miss cross-project dependencies. This workflow makes them analyze first, map the current system to the target state, and implement in controlled phases
+## Skills
 
-Explore more Rosetta workflows and skills in the [Usage Guide](/rosetta/docs/usage-guide/).
+1. `planning`, `tech-specs`: AI uses to turn a request into a clear plan and actionable specs.
+2. `orchestration`: AI uses to coordinate a team of subagents for large tasks.
+3. `questioning`, `hitl`: AI uses to be more human-oriented by asking questions and pausing for review.
+4. `research`, `reverse-engineering`: AI uses to investigate existing systems before acting.
+5. `coding`, `debugging`, `testing`: AI uses for implementation, root-cause analysis, and validation.
 
 ## Supported IDEs and Agents
 


### PR DESCRIPTION
# Summary

This PR updates the main onboarding documentation to make Rosetta more developer-facing and easier to scan. Instead of focusing only on what Rosetta is, it now explains which workflows a developer should actually use, what guardrails exist during execution, and which core skills are most relevant in practice.

The changes were made in two places so the repository entry point and the website stay aligned:

- `README.md`

- `docs/web/docs/introduction.md `

What was added:

- A new Workflows section describing the main Rosetta workflows in practical terms: coding-flow, requirements, authoring-flow, testgen-flow, api-aqa-flow, ui-aqa-flow, code-analysis-flow, help-flow, init-workspace-flow
- A short Guardrails section explaining the main execution protections in simple “AI will not...” language.
- A short Skills section summarizing the most useful core skills such as planning, tech-specs, orchestration, questioning, hitl, research, reverse-engineering, coding, debugging, and testing.

Closes issue [#136](https://github.com/griddynamics/rosetta/issues/136)