### PR TITLE
fix(ci): route Anthropic API calls through Bifrost gateway

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -119,7 +119,8 @@ jobs:
 
       - name: Run Curiocity E2E suite
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.BIFROST_API_KEY }}
+          ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           mkdir -p "$RESULTS_DIR"

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -121,6 +121,8 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.BIFROST_API_KEY }}
           ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
+          ENABLE_TOOL_SEARCH: "true"
+          CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           mkdir -p "$RESULTS_DIR"

--- a/.github/workflows/repo-analysis.yml
+++ b/.github/workflows/repo-analysis.yml
@@ -25,6 +25,8 @@ jobs:
     timeout-minutes: 60
     env:
       ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
+      ENABLE_TOOL_SEARCH: "true"
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/repo-analysis.yml
+++ b/.github/workflows/repo-analysis.yml
@@ -5,7 +5,8 @@ name: Rosetta Repo Analysis
 # and creates/updates stories automatically using Claude + Atlassian MCP.
 #
 # Required GitHub Secrets:
-#   - ANTHROPIC_API_KEY: Claude API key
+#   - BIFROST_HOST_NAME: Bifrost gateway hostname (no protocol/port/path), routes Anthropic API calls through Bifrost
+#   - BIFROST_API_KEY: Bifrost-issued API key
 #   - JIRA_API_KEY: Atlassian API token
 #   - CONFLUENCE_API_KEY: Atlassian API token (Confluence)
 #   - JIRA_CONFLUENCE_API_EMAIL: Atlassian account email for API auth
@@ -22,6 +23,8 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
 
     steps:
       - name: Checkout repository
@@ -42,7 +45,7 @@ jobs:
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.BIFROST_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}
           prompt: "MUST APPLY AND FULLY EXECUTE FULLY AUTONOMOUSLY WITHOUT ANY USER INTERACTION OR QUESTIONS, No HITL: .github/prompts/repo-analysis.md"

--- a/.github/workflows/repo-implement.yml
+++ b/.github/workflows/repo-implement.yml
@@ -5,7 +5,8 @@ name: Rosetta Story Implementer
 # → parallel implementation subagents that create a branch, write code, and open a PR.
 #
 # Required GitHub Secrets:
-#   - ANTHROPIC_API_KEY
+#   - BIFROST_HOST_NAME: Bifrost gateway hostname (no protocol/port/path), routes Anthropic API calls through Bifrost
+#   - BIFROST_API_KEY: Bifrost-issued API key
 #   - JIRA_API_KEY
 #   - CONFLUENCE_API_KEY
 #   - JIRA_CONFLUENCE_API_EMAIL
@@ -51,6 +52,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
 
     strategy:
       matrix: ${{ fromJSON(needs.load-stories.outputs.matrix) }}
@@ -83,7 +86,7 @@ jobs:
       - name: Implement — ${{ matrix.story_key }}
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.BIFROST_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}
           prompt: |

--- a/.github/workflows/repo-implement.yml
+++ b/.github/workflows/repo-implement.yml
@@ -54,6 +54,8 @@ jobs:
       pull-requests: write
     env:
       ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
+      ENABLE_TOOL_SEARCH: "true"
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
 
     strategy:
       matrix: ${{ fromJSON(needs.load-stories.outputs.matrix) }}

--- a/.github/workflows/repo-plan.yml
+++ b/.github/workflows/repo-plan.yml
@@ -54,6 +54,8 @@ jobs:
     timeout-minutes: 60
     env:
       ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
+      ENABLE_TOOL_SEARCH: "true"
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
 
     strategy:
       matrix: ${{ fromJSON(needs.load-stories.outputs.matrix) }}

--- a/.github/workflows/repo-plan.yml
+++ b/.github/workflows/repo-plan.yml
@@ -5,7 +5,8 @@ name: Rosetta Story Planner
 # → parallel planning subagents that write implementation plan + specs back to Jira.
 #
 # Required GitHub Secrets:
-#   - ANTHROPIC_API_KEY
+#   - BIFROST_HOST_NAME: Bifrost gateway hostname (no protocol/port/path), routes Anthropic API calls through Bifrost
+#   - BIFROST_API_KEY: Bifrost-issued API key
 #   - JIRA_API_KEY
 #   - CONFLUENCE_API_KEY
 #   - JIRA_CONFLUENCE_API_EMAIL
@@ -51,6 +52,8 @@ jobs:
     if: needs.load-stories.outputs.has_work == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
 
     strategy:
       matrix: ${{ fromJSON(needs.load-stories.outputs.matrix) }}
@@ -75,7 +78,7 @@ jobs:
       - name: Plan — ${{ matrix.story_key }}
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.BIFROST_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}
           prompt: |

--- a/.github/workflows/repo-triage.yml
+++ b/.github/workflows/repo-triage.yml
@@ -6,7 +6,8 @@ name: Rosetta GitHub Triage
 # /rosetta slash commands in comments.
 #
 # Required GitHub Secrets:
-#   - ANTHROPIC_API_KEY
+#   - BIFROST_HOST_NAME: Bifrost gateway hostname (no protocol/port/path), routes Anthropic API calls through Bifrost
+#   - BIFROST_API_KEY: Bifrost-issued API key
 #   - JIRA_API_KEY
 #   - CONFLUENCE_API_KEY
 #   - JIRA_CONFLUENCE_API_EMAIL
@@ -29,6 +30,8 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
+    env:
+      ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
     if: |
       !(github.event_name == 'pull_request_target' && (github.event.pull_request.draft == true || contains(github.event.pull_request.title, 'WIP') || contains(github.event.pull_request.title, '[WIP]'))) &&
       !(github.event_name == 'issue_comment' && !contains(github.event.comment.body, '/rosetta')) &&
@@ -63,7 +66,7 @@ jobs:
       - name: Triage
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.BIFROST_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           path_to_bun_executable: ${{ steps.bun.outputs.bun-path }}
           plugin_marketplaces: |

--- a/.github/workflows/repo-triage.yml
+++ b/.github/workflows/repo-triage.yml
@@ -32,6 +32,8 @@ jobs:
       pull-requests: write
     env:
       ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
+      ENABLE_TOOL_SEARCH: "true"
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
     if: |
       !(github.event_name == 'pull_request_target' && (github.event.pull_request.draft == true || contains(github.event.pull_request.title, 'WIP') || contains(github.event.pull_request.title, '[WIP]'))) &&
       !(github.event_name == 'issue_comment' && !contains(github.event.comment.body, '/rosetta')) &&

--- a/.github/workflows/validate-prompts.yml
+++ b/.github/workflows/validate-prompts.yml
@@ -113,6 +113,8 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.BIFROST_API_KEY }}
           ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
+          ENABLE_TOOL_SEARCH: "true"
+          CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
           BASE_REF: ${{ steps.changed-files.outputs.base_ref }}
         run: |
           echo "Validating prompts..."

--- a/.github/workflows/validate-prompts.yml
+++ b/.github/workflows/validate-prompts.yml
@@ -4,7 +4,8 @@ name: Validate Prompts
 # when changes are made to the instructions/ folder in pull requests.
 #
 # Required GitHub Secrets:
-#   - ANTHROPIC_API_KEY: API key for Claude Code CLI
+#   - BIFROST_HOST_NAME: Bifrost gateway hostname (no protocol/port/path), routes Anthropic API calls through Bifrost
+#   - BIFROST_API_KEY: Bifrost-issued API key for Claude Code CLI
 #
 # The workflow:
 # - Detects changed files in instructions/ folder
@@ -110,7 +111,8 @@ jobs:
         id: validate
         if: steps.changed-files.outputs.count > 0
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.BIFROST_API_KEY }}
+          ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
           BASE_REF: ${{ steps.changed-files.outputs.base_ref }}
         run: |
           echo "Validating prompts..."

--- a/.github/workflows/validate-test-cases.yml
+++ b/.github/workflows/validate-test-cases.yml
@@ -10,7 +10,7 @@
 # Required: Claude Code CLI. Set VALIDATE_CLI_CMD env or use default (claude).
 # CLI runs from workspace: cd <dir> && claude -p "$(cat prompt-file)" --output-format text
 #
-# Optional: ANTHROPIC_API_KEY or Claude Code auth for CI.
+# Optional: BIFROST_API_KEY + BIFROST_HOST_NAME (routes via Bifrost) or Claude Code auth for CI.
 
 name: Validate Test Cases
 
@@ -85,7 +85,8 @@ jobs:
         id: validate
         if: steps.changed.outputs.count > 0
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.BIFROST_API_KEY }}
+          ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
           CHANGED_FILES: ${{ steps.changed.outputs.files }}
           BASE_SHA: ${{ steps.base.outputs.sha }}
           REPO_ROOT: ${{ github.workspace }}

--- a/.github/workflows/validate-test-cases.yml
+++ b/.github/workflows/validate-test-cases.yml
@@ -87,6 +87,8 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.BIFROST_API_KEY }}
           ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
+          ENABLE_TOOL_SEARCH: "true"
+          CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
           CHANGED_FILES: ${{ steps.changed.outputs.files }}
           BASE_SHA: ${{ steps.base.outputs.sha }}
           REPO_ROOT: ${{ github.workspace }}


### PR DESCRIPTION
## Summary

- Migrates all Anthropic API call sites in CI to go through Bifrost, per the scope agreed on #139.
- 4 `claude-code-action` workflows (`repo-triage`, `repo-implement`, `repo-analysis`, `repo-plan`): job-level `ANTHROPIC_BASE_URL` env var added (consumed by the action's internal `env.ANTHROPIC_BASE_URL` passthrough) and `anthropic_api_key` input switched from `secrets.ANTHROPIC_API_KEY` to `secrets.BIFROST_API_KEY`.
- 3 Claude Code CLI workflows (`validate-prompts`, `validate-test-cases`, `e2e-testing`): step-level `ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY` (now sourced from `secrets.BIFROST_API_KEY`) since the CLI reads these directly from the process environment.
- `src/rosettify-prompts` and `src/curiocity` needed no code changes — both already resolve `ANTHROPIC_BASE_URL` (or their own override vars) per the triage comment on #139; only the secret/env values need to be set where those tools run.
- Uses the existing repo secrets `BIFROST_HOST_NAME` (domain only) and `BIFROST_API_KEY` as requested in the issue.

## Assumption to verify

`ANTHROPIC_BASE_URL` is built as `https://${{ secrets.BIFROST_HOST_NAME }}/anthropic` — the `/anthropic` path suffix is Bifrost's documented Anthropic-compatible drop-in endpoint. Please confirm this matches the actual Bifrost gateway deployment/routing config before merging; if the deployed path differs, only the path suffix in these files needs to change.

Closes #139

## Test plan

- [ ] YAML validated for all 7 changed workflow files (done locally via `Ruby YAML.load_file`)
- [ ] Confirm `BIFROST_HOST_NAME` / `BIFROST_API_KEY` secrets are populated at the repo level
- [ ] Trigger `repo-triage` (e.g. via a `/rosetta` comment) and confirm the Claude call routes through Bifrost successfully
- [ ] Trigger `validate-prompts` on a PR touching `instructions/` and confirm it completes