### PR TITLE
#175 rosetta-mcp-dockerhub.yaml uses actions/setup-node@v4, siblings use @v5

### DIFF
--- a/.github/workflows/rosetta-mcp-dockerhub.yaml
+++ b/.github/workflows/rosetta-mcp-dockerhub.yaml
@@ -50,7 +50,7 @@ jobs:
           echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 


### PR DESCRIPTION
Closes #175

## Summary
- Bump `actions/setup-node` from `@v4` to `@v5` in `rosetta-mcp-dockerhub.yaml` (line 53) to match every other workflow in the fleet (ci-curiocity, ci-rosetta-hooks, ci-rosetta-mcp, publish-rosetta-mcp, ci-rosettify-*, etc.).

## CI Workflow Changes
This PR modifies a file under `.github/workflows/` — exactly the single-line version bump the issue asked for, no other changes bundled.

## Testing notes
- Confirmed repo-wide via grep that no other `actions/setup-node@v4` references remain under `.github/workflows/`.
- No unit tests apply; this is a like-for-like CI action version pin change with no functional inputs affected (`node-version: '24'` unchanged).

## Assumptions
None — straightforward version alignment already proven safe across every other workflow in the repo.