### PR TITLE
Seven-lane board flow: distinct load, claim and terminal lanes per pipeline

### DIFF
--- a/.github/prompts/repo-implement-code.md
+++ b/.github/prompts/repo-implement-code.md
@@ -27,7 +27,7 @@ Invoke `rosetta:coding-flow` with the Skill tool. If it does not resolve, read
 `instructions/r3/core/workflows/coding-flow.md` from this checkout and follow it
 directly. Run only the phases that turn an approved plan into code. The
 planning half already ran and its output is the `## 🤖 Rosetta Plan` section of the
-issue description; a human approved it by moving the card to "Ready".
+issue description; the user approved it by moving the card to "Scheduled".
 
 - SKIP phases 1 (discovery), 2 (design), 4 (tech_plan) and 5 (review_plan). Do not
   re-plan, re-design, or re-specify. Treat that section as the approved output of
@@ -62,14 +62,14 @@ You always must "simulate" how the entire AI coding agent flow works if instruct
 ## Constraints
 
 - You MAY create and modify files under `.github/workflows/`; the push credential carries the `workflow` scope. Treat these as high blast radius — they can alter the guardrails that constrain this pipeline. Keep the edit to exactly what the issue asks, call it out explicitly in the PR body, and never bundle it with unrelated changes.
-- If a push is rejected over workflow permissions, do NOT retry or work around it. Post the exact change as a fenced diff in the PR description under `## CI Workflow Changes (Manual)` and as an issue comment labeled `⚠️ Manual CI Change Required`. If that was the whole issue, **leave the card at "In progress"** — do NOT return it to "Backlog", which is re-planned every cycle and would loop forever. "In progress" is picked up by no pipeline and reads as "needs a human".
+- If a push is rejected over workflow permissions, do NOT retry or work around it. Post the exact change as a fenced diff in the PR description under `## CI Workflow Changes (Manual)` and as an issue comment labeled `⚠️ Manual CI Change Required`. If that was the whole issue, **leave the card at "In progress"** — no pipeline loads that lane, so it waits for the user instead of being retried.
 - Any edit under `instructions/r*/**` is mirrored into the generated `plugins/**` trees. Before opening the PR, grep the WHOLE repo (not just the directory you edited) for the string you changed. Either update the generated copies too, or state explicitly in the PR body which files still carry the old content and that a plugin regeneration is required. A directory-scoped grep that cannot fail is not verification.
 - ONLY access the issue provided. Do NOT read or modify other GitHub issues except to reference them by number when relevant.
 - ONLY work within the current repository. Do NOT push to forks or other remotes.
-- The issue must currently be on the Rosetta Automation Board (project 57) with Status "Ready".
-- If the issue description has no `## 🤖 Rosetta Plan` section from the planning phase, post a comment asking for planning to be completed first, move the item back to "Backlog" via `gh project item-edit`, and stop.
+- The card is at Status "In progress": the workflow claimed it before invoking you. You move it to "In review" once the PR is open, and nowhere else.
+- If the issue description has no `## 🤖 Rosetta Plan` section from the planning phase, post a comment asking for planning to be completed first, move the item back to "Backlog" via `gh project item-edit` so the planner picks it up, and stop.
 
-## Phase 1 — Claim the Issue
+## Phase 1 — Read the Issue and the Plan
 
 1. ALWAYS read the issue in full before anything else — body AND every comment:
    `gh issue view <ISSUE_NUMBER> --json title,body,labels,comments`. The plan lives in
@@ -77,13 +77,7 @@ You always must "simulate" how the entire AI coding agent flow works if instruct
    clarifications and later corrections, so read them all and implement the latest
    agreed version.
 2. Check for existing work: run `gh pr list --search "#<ISSUE_NUMBER>" --state open`. If an open branch or PR already exists for this issue, post a comment with the existing branch/PR URL and stop — do not create a duplicate branch.
-3. Immediately claim the item by moving it to "In progress":
-   ```bash
-   gh project item-edit --id "<PROJECT_ITEM_ID>" --project-id "<PROJECT_ID>" \
-     --field-id "<STATUS_FIELD_ID>" --single-select-option-id "<IN_PROGRESS_OPTION_ID>"
-   ```
-4. Post a comment: `🤖 Implementation started by AI agent.`
-5. Read the `## 🤖 Rosetta Plan` section of the issue description. If missing, abort (see Constraints).
+3. Read the `## 🤖 Rosetta Plan` section of the issue description. If missing, abort (see Constraints).
 
 ## Phase 2 — Prepare Branch
 

--- a/.github/prompts/repo-implement-plan.md
+++ b/.github/prompts/repo-implement-plan.md
@@ -25,7 +25,9 @@
 
 You are an automated planning agent. Your job is to produce an implementation plan
 and tech specs for a single GitHub issue on the Rosetta Automation Board, write them
-into the issue description, then move the board card to "In progress".
+into the issue description, then move the board card to "Ready".
+
+The card is already at "Planning": the workflow claimed it before invoking you.
 
 ## Method — run `rosetta:coding-flow`, planning half only
 
@@ -39,9 +41,9 @@ across two runs: you do the thinking, the implementer does the doing.
 - SKIP phases 7-13 entirely (implementation, review_code, impl_validation, tests,
   review_tests, final_validation). Write no code, run no tests.
 - Phases 3 and 6 are HITL gates and this pipeline is `No HITL`. Do not block on them:
-  phase 6 (user_review_plan) is satisfied out-of-band by a human reading your plan
-  comment and moving the board card from "In progress" to "Ready". That board move is
-  the approval — never make it yourself.
+  phase 6 (user_review_plan) is satisfied out-of-band by the user reading your plan
+  and moving the card from "Ready" to "Scheduled". That move is the approval — never
+  make it yourself.
 - Dispatch the phase subagents `coding-flow` calls for (`discoverer`, `architect`,
   `reviewer`) under the Subagent constraint above.
 
@@ -71,10 +73,10 @@ You always must "simulate" how the entire AI coding agent flow works if instruct
 - ONLY access the issue provided. Do NOT read or modify other GitHub issues except to
   reference them by number when relevant (e.g. dependencies).
 - Do NOT commit code, create branches, or modify repository files.
-- The issue must currently be on the Rosetta Automation Board (project 57) with
-  Status "Backlog". If it is not, post a comment explaining why and stop.
+- The card is at Status "Planning" and you move it to "Ready" when the plan is
+  written. Never move it to "Scheduled" — that move is the user's approval.
 
-## Phase 1 — Claim the Issue
+## Phase 1 — Read the Issue
 
 1. ALWAYS read the issue in full before anything else — body AND every comment:
    `gh issue view <ISSUE_NUMBER> --json title,body,labels,comments`. Later comments
@@ -83,17 +85,8 @@ You always must "simulate" how the entire AI coding agent flow works if instruct
    open PR already references this issue, post a comment noting the PR URL and stop —
    planning is likely already done.
 3. Check the issue description for an existing `## 🤖 Rosetta Plan` section. If found,
-   treat this as a re-plan request (the human moved the card back to Backlog) and replace
+   treat this as a re-plan request (the user moved the card back to Backlog) and replace
    that section in place — never leave two.
-4. Immediately claim the item by moving it to "In progress":
-   ```bash
-   gh project item-edit --id "<PROJECT_ITEM_ID>" --project-id "<PROJECT_ID>" \
-     --field-id "<STATUS_FIELD_ID>" --single-select-option-id "<IN_PROGRESS_OPTION_ID>"
-   ```
-   (`<IN_PROGRESS_OPTION_ID>` is the `"In progress"` entry in the Status option IDs JSON
-   provided in the prompt.) This is both the concurrency lock and the visible signal that
-   AI has started work — do this before any other action.
-5. Post a comment: `🤖 Planning started by AI agent.`
 
 ## Phase 2 — Review Codebase
 
@@ -140,13 +133,19 @@ Reference other issues by `#<number>` (GitHub auto-links these) and files by the
 4. **If the issue is not an implementable change** — a question, a research or
    fact-check request, an investigation — do NOT invent a plan and do NOT write a
    `## 🤖 Rosetta Plan` section. Answer in a comment, state plainly in that comment
-   that the issue is not implementable as written and needs a human to split it into
-   actionable tickets, and leave the card for that human. An empty plan section is
-   worse than none: the implementer treats it as approved work.
-5. **Do not move the card past "In progress."** A human reviews the plan and manually
-   moves it to "Ready" when satisfied — the agent never promotes it itself. If the plan
-   surfaces blockers that mean this issue should NOT proceed, say so explicitly in the
-   comment so the human can move it back to "Backlog" or close it instead.
+   that the issue is not implementable as written and needs the user to split it into
+   actionable tickets, and leave the card at "Planning" for them. An empty plan section
+   is worse than none: the implementer treats it as approved work.
+5. Once the plan is written, move the card to "Ready":
+   ```bash
+   gh project item-edit --id "<PROJECT_ITEM_ID>" --project-id "<PROJECT_ID>" \
+     --field-id "<STATUS_FIELD_ID>" --single-select-option-id "<READY_OPTION_ID>"
+   ```
+   (`<READY_OPTION_ID>` is the `"Ready"` entry in the Status option IDs JSON provided in
+   the prompt.) Do this only when a plan actually exists — it is the signal that the
+   plan is waiting for the user. Never move the card to "Scheduled": that is the user's
+   approval. If the plan surfaces blockers meaning this issue should NOT proceed, say so
+   in the comment and leave the card at "Planning".
 
 ## Important Notes
 
@@ -161,5 +160,5 @@ Print a summary:
 Issue: #<number>
 Files to modify: <list>
 Open questions: <count>
-Board status: In progress
+Board status: Ready
 ```

--- a/.github/scripts/load_stories.py
+++ b/.github/scripts/load_stories.py
@@ -6,9 +6,15 @@ Board: "Rosetta Automation Board" — org griddynamics, project number 57
 https://github.com/orgs/griddynamics/projects/57
 
 Filtering logic:
-  - Status "Backlog" + Priority set and not low → plan_matrix
-  - Status "Ready"                              → impl_matrix  (no priority gate:
-    a human moving a card to "Ready" is the decision to build it)
+  - Status "Backlog"   + Priority set and not low → plan_matrix
+  - Status "Scheduled"                            → impl_matrix  (no priority gate:
+    the user moving a card to "Scheduled" is the decision to build it)
+
+Each pipeline loads one lane, claims into a working lane, and ends in a third:
+Backlog -> Planning -> Ready for the planner, Scheduled -> In progress -> In review
+for the implementer. A terminal lane is never an input lane, so nothing can be
+re-processed, and a crashed run parks its card in a working lane that no pipeline
+loads rather than looping.
 
 Status is a Projects v2 single-select field. Priority is NOT — it is a native
 GitHub *Issue* field surfaced on the board as a derived column, so it is invisible
@@ -203,8 +209,8 @@ def collect_matrices(items: list[dict]) -> tuple[list[dict], list[dict]]:
                 plan_items.append(entry)
             else:
                 skipped.append((item["number"], priority or "unset"))
-        elif item.get("status") == "Ready":
-            # No priority gate here: a human moving a card to "Ready" is the
+        elif item.get("status") == "Scheduled":
+            # No priority gate here: the user moving a card to "Scheduled" is the
             # decision to build it.
             impl_items.append(entry)
 

--- a/.github/scripts/test_load_stories.py
+++ b/.github/scripts/test_load_stories.py
@@ -45,9 +45,9 @@ def test_priority_gate_applies_to_backlog_only():
     plan, impl = module.collect_matrices([
         issue(1, status="Backlog", priority="P1"),
         issue(2, status="Backlog", priority="Low"),
-        issue(3, status="Backlog"),                    # unset
-        issue(4, status="Ready"),                      # unset, must still implement
-        issue(5, status="Ready", priority="Low"),      # low, must still implement
+        issue(3, status="Backlog"),                     # unset
+        issue(4, status="Scheduled"),                   # unset, must still implement
+        issue(5, status="Scheduled", priority="Low"),   # low, must still implement
     ])
     assert [e["issue_number"] for e in plan] == [1]
     assert [e["issue_number"] for e in impl] == [4, 5]
@@ -55,17 +55,40 @@ def test_priority_gate_applies_to_backlog_only():
 
 # ── Status selection ────────────────────────────────────────────────────────────
 
-def test_only_backlog_and_ready_are_selected():
+def test_only_backlog_and_scheduled_are_selected():
     plan, impl = module.collect_matrices([
         issue(1, status="Backlog", priority="P1"),
-        issue(2, status="Ready"),
-        issue(3, status="In progress", priority="P1"),
-        issue(4, status="In review", priority="P1"),
-        issue(5, status="Done", priority="P1"),
-        issue(6, priority="P1"),                       # status unset
+        issue(2, status="Scheduled"),
+        issue(3, status="Planning", priority="P1"),
+        issue(4, status="Ready", priority="P1"),
+        issue(5, status="In progress", priority="P1"),
+        issue(6, status="In review", priority="P1"),
+        issue(7, status="Done", priority="P1"),
+        issue(8, priority="P1"),                       # status unset
     ])
     assert [e["issue_number"] for e in plan] == [1]
     assert [e["issue_number"] for e in impl] == [2]
+
+
+def test_working_lanes_are_never_picked_up():
+    """Planning and In progress are the lanes a pipeline claims into. Loading either
+    would let a crashed run be retried forever, which is the whole reason the input
+    and terminal lanes are distinct."""
+    plan, impl = module.collect_matrices([
+        issue(1, status="Planning", priority="Urgent"),
+        issue(2, status="In progress", priority="Urgent"),
+    ])
+    assert plan == [] and impl == []
+
+
+def test_terminal_lanes_are_never_picked_up():
+    """Ready is the planner's terminal lane and In review the implementer's; loading
+    them would re-process finished work."""
+    plan, impl = module.collect_matrices([
+        issue(1, status="Ready", priority="Urgent"),
+        issue(2, status="In review", priority="Urgent"),
+    ])
+    assert plan == [] and impl == []
 
 
 def test_status_match_is_case_and_whitespace_sensitive():
@@ -81,7 +104,7 @@ def test_status_match_is_case_and_whitespace_sensitive():
 def test_closed_issues_are_never_selected():
     plan, impl = module.collect_matrices([
         issue(1, status="Backlog", priority="P1", state="CLOSED"),
-        issue(2, status="Ready", state="CLOSED"),
+        issue(2, status="Scheduled", state="CLOSED"),
     ])
     assert plan == [] and impl == []
 

--- a/.github/workflows/repo-implement.yml
+++ b/.github/workflows/repo-implement.yml
@@ -99,6 +99,29 @@ jobs:
           git config user.name "github-actions[bot]"
           git remote set-url origin https://x-access-token:${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}@github.com/${{ github.repository }}
 
+      # An auto-triggered run can fire while the issue is still being edited. Wait until
+      # it has been quiet for 5 minutes before claiming it, so the agent never implements
+      # a half-written plan. Manual dispatch skips this — the user chose the moment.
+      # (This is the runner's own shell; the agent-side sleep restrictions do not apply.)
+      - name: Debounce — wait for the issue to settle
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}
+          ISSUE: ${{ matrix.issue_number }}
+        run: |
+          previous=""
+          for attempt in $(seq 1 6); do
+            current=$(gh issue view "$ISSUE" --json updatedAt -q .updatedAt)
+            if [ "$current" = "$previous" ]; then
+              echo "Issue #$ISSUE unchanged for 5 minutes (last update $current) — proceeding."
+              exit 0
+            fi
+            echo "Issue #$ISSUE updated at $current — waiting 5 minutes (attempt $attempt/6)."
+            previous="$current"
+            sleep 300
+          done
+          echo "::warning::Issue #$ISSUE still changing after 30 minutes — proceeding anyway."
+
       # Claiming needs no judgement, so it is done here rather than costing an agent
       # turn. jq -e fails the step if the board has no "In progress" option, instead
       # of letting the agent run against a lane that does not exist.

--- a/.github/workflows/repo-implement.yml
+++ b/.github/workflows/repo-implement.yml
@@ -27,6 +27,11 @@ on:
   schedule:
     - cron: '30 */3 * * *'
     - cron: '0 3 * * *'
+  # Every issue activity type, unfiltered. The payload is ignored: the event is only a
+  # doorbell and the job loads the whole board, so this also picks up a card the user
+  # moved to Scheduled — board Status changes raise only the organization-scoped
+  # projects_v2_item, which a repository workflow cannot subscribe to.
+  issues:
   workflow_dispatch:
 
 jobs:
@@ -45,8 +50,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      # Issue events plus a 3-hourly schedule means runs can overlap, and the claim is
+      # not atomic — two runs could read the same card as Scheduled before either claims
+      # it and both would open a branch. Bail out instead: safe, because the in-flight run
+      # or the next event picks the work up. Preferred over a `concurrency:` group, which
+      # would either queue runs or cancel one mid-flight, stranding its card In progress.
+      - name: Skip if another run is already in progress
+        id: inflight
+        env:
+          GH_TOKEN: ${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          others=$(gh run list --workflow repo-implement.yml --status in_progress \
+                     --limit 100 --json databaseId \
+                     -q "[.[] | select(.databaseId != ${RUN_ID})] | length")
+          if [ "${others:-0}" -gt 0 ]; then
+            echo "busy=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$others other implementer run(s) in progress — skipping this one."
+          fi
+
       - name: Load board items
         id: load
+        if: steps.inflight.outputs.busy != 'true'
         env:
           GH_TOKEN: ${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}
         run: python .github/scripts/load_stories.py
@@ -54,7 +80,11 @@ jobs:
       - name: Summary
         run: |
           echo "## Implementer — Board Load" >> $GITHUB_STEP_SUMMARY
-          echo "- Issues to implement: ${{ steps.load.outputs.impl_count }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.inflight.outputs.busy }}" = "true" ]; then
+            echo "- Skipped: another implementer run is in progress" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- Issues to implement: ${{ steps.load.outputs.impl_count }}" >> $GITHUB_STEP_SUMMARY
+          fi
 
   # ── Implementation subagents (parallel, one per issue) ────────────────────────
   implement-story:

--- a/.github/workflows/repo-implement.yml
+++ b/.github/workflows/repo-implement.yml
@@ -99,12 +99,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git remote set-url origin https://x-access-token:${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}@github.com/${{ github.repository }}
 
-      # An auto-triggered run can fire while the issue is still being edited. Wait until
-      # it has been quiet for 5 minutes before claiming it, so the agent never implements
-      # a half-written plan. Manual dispatch skips this — the user chose the moment.
+      # An issue event fires while the issue is still being edited, so wait until it has
+      # been quiet for 5 minutes before claiming it — otherwise the agent implements a
+      # plan still being revised. Only issue events need this: a schedule fires on its
+      # own clock, and manual dispatch means the user picked the moment.
       # (This is the runner's own shell; the agent-side sleep restrictions do not apply.)
       - name: Debounce — wait for the issue to settle
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name == 'issues'
         env:
           GH_TOKEN: ${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}
           ISSUE: ${{ matrix.issue_number }}

--- a/.github/workflows/repo-implement.yml
+++ b/.github/workflows/repo-implement.yml
@@ -8,10 +8,12 @@ name: Rosetta Story Implementer
 # Board membership is the scoping mechanism (replaces the old Jira epic parent):
 # only issues added to that project are eligible for AI implementation.
 #
-# Status field flow on the board:
-#   Ready -> (implement-agent claims, moves to "In progress", implements, opens
-#             a PR referencing the issue) -> "In review" (moved automatically —
-#             this just reflects where the PR is, not a human decision)
+# Status field flow on the board (see docs/AUTOMATION-ARCHITECTURE.md):
+#   Scheduled -> In progress -> In review
+#   Loads "Scheduled" (no priority filter — the user moving a card there is the
+#   decision to build it). The workflow claims the card into "In progress" before
+#   invoking the agent; the agent implements, opens a PR referencing the issue, and
+#   moves the card to "In review" for the user to review.
 #
 # Required GitHub Secrets:
 #   - BIFROST_HOST_NAME: Bifrost gateway hostname (no protocol/port/path), routes Anthropic API calls through Bifrost
@@ -97,6 +99,23 @@ jobs:
           git config user.name "github-actions[bot]"
           git remote set-url origin https://x-access-token:${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}@github.com/${{ github.repository }}
 
+      # Claiming needs no judgement, so it is done here rather than costing an agent
+      # turn. jq -e fails the step if the board has no "In progress" option, instead
+      # of letting the agent run against a lane that does not exist.
+      - name: Claim — move card to In progress
+        env:
+          GH_TOKEN: ${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}
+          ITEM_ID: ${{ matrix.item_id }}
+          ISSUE: ${{ matrix.issue_number }}
+          PROJECT_ID: ${{ needs.load-stories.outputs.project_id }}
+          FIELD_ID: ${{ needs.load-stories.outputs.status_field_id }}
+          OPTION_IDS: ${{ needs.load-stories.outputs.status_option_ids }}
+        run: |
+          option_id=$(printf '%s' "$OPTION_IDS" | jq -er '."In progress"')
+          gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" \
+            --field-id "$FIELD_ID" --single-select-option-id "$option_id"
+          gh issue comment "$ISSUE" --body "🤖 Implementation started by AI agent."
+
       - name: Implement — issue #${{ matrix.issue_number }}
         uses: anthropics/claude-code-action@v1
         env:
@@ -149,3 +168,16 @@ jobs:
       - name: Verify the run did real work
         if: always()
         run: python3 .github/scripts/check_trace.py /home/runner/work/_temp/claude-execution-output.json
+
+      # The card stays in the In progress lane, which no pipeline loads, so a failed
+      # run waits for a human instead of being retried. Say so on the issue.
+      - name: Report failure on the issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}
+          ISSUE: ${{ matrix.issue_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue comment "$ISSUE" --body "⚠️ Implementation run failed — see [the run log]($RUN_URL).
+
+          The card is left at \`In progress\`, which no pipeline picks up, so it will not be retried automatically. Move it back to \`Scheduled\` to retry, or to \`Backlog\` to re-plan first."

--- a/.github/workflows/repo-plan.yml
+++ b/.github/workflows/repo-plan.yml
@@ -88,12 +88,13 @@ jobs:
           bun-version: 1.3.6
           token: ${{ github.token }}
 
-      # An auto-triggered run can fire while the issue is still being edited. Wait until
-      # it has been quiet for 5 minutes before claiming it, so the agent never plans a
-      # half-written issue. Manual dispatch skips this — the user chose the moment.
+      # An issue event fires while the issue is still being edited, so wait until it has
+      # been quiet for 5 minutes before claiming it — otherwise the agent plans a
+      # half-written issue. Only issue events need this: a schedule fires on its own
+      # clock, and manual dispatch means the user picked the moment.
       # (This is the runner's own shell; the agent-side sleep restrictions do not apply.)
       - name: Debounce — wait for the issue to settle
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name == 'issues'
         env:
           GH_TOKEN: ${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}
           ISSUE: ${{ matrix.issue_number }}

--- a/.github/workflows/repo-plan.yml
+++ b/.github/workflows/repo-plan.yml
@@ -65,7 +65,8 @@ jobs:
     needs: load-stories
     if: needs.load-stories.outputs.has_work == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 30 of these can go to the debounce loop before the agent starts.
+    timeout-minutes: 90
     env:
       ANTHROPIC_BASE_URL: https://${{ secrets.BIFROST_HOST_NAME }}/anthropic
       ENABLE_TOOL_SEARCH: "true"
@@ -86,6 +87,29 @@ jobs:
         with:
           bun-version: 1.3.6
           token: ${{ github.token }}
+
+      # An auto-triggered run can fire while the issue is still being edited. Wait until
+      # it has been quiet for 5 minutes before claiming it, so the agent never plans a
+      # half-written issue. Manual dispatch skips this — the user chose the moment.
+      # (This is the runner's own shell; the agent-side sleep restrictions do not apply.)
+      - name: Debounce — wait for the issue to settle
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}
+          ISSUE: ${{ matrix.issue_number }}
+        run: |
+          previous=""
+          for attempt in $(seq 1 6); do
+            current=$(gh issue view "$ISSUE" --json updatedAt -q .updatedAt)
+            if [ "$current" = "$previous" ]; then
+              echo "Issue #$ISSUE unchanged for 5 minutes (last update $current) — proceeding."
+              exit 0
+            fi
+            echo "Issue #$ISSUE updated at $current — waiting 5 minutes (attempt $attempt/6)."
+            previous="$current"
+            sleep 300
+          done
+          echo "::warning::Issue #$ISSUE still changing after 30 minutes — proceeding anyway."
 
       # Claiming needs no judgement, so it is done here rather than costing an agent
       # turn. jq -e fails the step if the board has no "Planning" option, instead of

--- a/.github/workflows/repo-plan.yml
+++ b/.github/workflows/repo-plan.yml
@@ -27,6 +27,10 @@ on:
   schedule:
     - cron: '0 */2 * * *'
     - cron: '0 1 * * *'
+  # Every issue activity type, unfiltered. The payload is ignored: the event is only a
+  # doorbell and the job loads the whole board, so a dropped or irrelevant event costs
+  # one fast load that exits with has_work=false, and nothing is ever stranded.
+  issues:
   workflow_dispatch:
 
 permissions:
@@ -49,8 +53,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      # Issue events plus a 2-hourly schedule means runs can overlap, and the claim is
+      # not atomic — two runs could read the same card as Backlog before either claims
+      # it. Bail out instead: safe, because the in-flight run or the next event picks the
+      # work up. Preferred over a `concurrency:` group, which would either queue runs or
+      # cancel one mid-flight, stranding its card in the Planning lane.
+      - name: Skip if another run is already in progress
+        id: inflight
+        env:
+          GH_TOKEN: ${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          others=$(gh run list --workflow repo-plan.yml --status in_progress \
+                     --limit 100 --json databaseId \
+                     -q "[.[] | select(.databaseId != ${RUN_ID})] | length")
+          if [ "${others:-0}" -gt 0 ]; then
+            echo "busy=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$others other planner run(s) in progress — skipping this one."
+          fi
+
       - name: Load board items
         id: load
+        if: steps.inflight.outputs.busy != 'true'
         env:
           GH_TOKEN: ${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}
         run: python .github/scripts/load_stories.py
@@ -58,7 +83,11 @@ jobs:
       - name: Summary
         run: |
           echo "## Planner — Board Load" >> $GITHUB_STEP_SUMMARY
-          echo "- Issues to plan: ${{ steps.load.outputs.plan_count }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.inflight.outputs.busy }}" = "true" ]; then
+            echo "- Skipped: another planner run is in progress" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- Issues to plan: ${{ steps.load.outputs.plan_count }}" >> $GITHUB_STEP_SUMMARY
+          fi
 
   # ── Planning subagents (parallel, one per issue) ─────────────────────────────
   plan-story:

--- a/.github/workflows/repo-plan.yml
+++ b/.github/workflows/repo-plan.yml
@@ -8,10 +8,12 @@ name: Rosetta Story Planner
 # Board membership is the scoping mechanism (replaces the old Jira epic parent):
 # only issues added to that project are eligible for AI planning.
 #
-# Status field flow on the board:
-#   Backlog -> (plan-agent claims, writes plan as an issue comment, leaves at
-#               "In progress" — a human reviews the plan and manually moves
-#               the card to "Ready" when satisfied; the agent never does this)
+# Status field flow on the board (see docs/AUTOMATION-ARCHITECTURE.md):
+#   Backlog -> Planning -> Ready
+#   Loads "Backlog" (only when Priority is set and not Low). The workflow claims the
+#   card into "Planning" before invoking the agent; the agent writes the plan into the
+#   issue description and moves the card to "Ready".
+#   "Ready" -> "Scheduled" is the user's plan-approval gate. The agent never makes it.
 #
 # Required GitHub Secrets:
 #   - BIFROST_HOST_NAME: Bifrost gateway hostname (no protocol/port/path), routes Anthropic API calls through Bifrost
@@ -85,6 +87,23 @@ jobs:
           bun-version: 1.3.6
           token: ${{ github.token }}
 
+      # Claiming needs no judgement, so it is done here rather than costing an agent
+      # turn. jq -e fails the step if the board has no "Planning" option, instead of
+      # letting the agent run against a lane that does not exist.
+      - name: Claim — move card to Planning
+        env:
+          GH_TOKEN: ${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}
+          ITEM_ID: ${{ matrix.item_id }}
+          ISSUE: ${{ matrix.issue_number }}
+          PROJECT_ID: ${{ needs.load-stories.outputs.project_id }}
+          FIELD_ID: ${{ needs.load-stories.outputs.status_field_id }}
+          OPTION_IDS: ${{ needs.load-stories.outputs.status_option_ids }}
+        run: |
+          option_id=$(printf '%s' "$OPTION_IDS" | jq -er '.Planning')
+          gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" \
+            --field-id "$FIELD_ID" --single-select-option-id "$option_id"
+          gh issue comment "$ISSUE" --body "🤖 Planning started by AI agent."
+
       - name: Plan — issue #${{ matrix.issue_number }}
         uses: anthropics/claude-code-action@v1
         env:
@@ -137,3 +156,16 @@ jobs:
       - name: Verify the run did real work
         if: always()
         run: python3 .github/scripts/check_trace.py /home/runner/work/_temp/claude-execution-output.json
+
+      # The card stays in the Planning lane, which no pipeline loads, so a failed run
+      # waits for a human instead of being retried. Say so on the issue.
+      - name: Report failure on the issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.SELF_AUTOMATION_PROJECTS_TOKEN }}
+          ISSUE: ${{ matrix.issue_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue comment "$ISSUE" --body "⚠️ Planning run failed — see [the run log]($RUN_URL).
+
+          The card is left at \`Planning\`, which no pipeline picks up, so it will not be retried automatically. Move it back to \`Backlog\` to re-plan."

--- a/docs/AUTOMATION-ARCHITECTURE.md
+++ b/docs/AUTOMATION-ARCHITECTURE.md
@@ -161,23 +161,23 @@ mechanism.** To plan fewer issues, set Priority on fewer issues. To implement fe
 move fewer cards to `Scheduled`. Any out-of-band scoping input would be a second control
 surface that bypasses the board and diverges from what the board shows.
 
-## Future: trigger the planner on issue events instead of cron
+## Triggers
 
-Add `on: issues:` — every issue activity type, no filter — to both workflows, and keep
-cron as a backstop.
+Both workflows run on `on: issues:` — every activity type, unfiltered — plus a cron
+backstop.
 
-The event is a doorbell: the payload is ignored, the workflow loads the whole board as
-it does on a cron tick, and picks up everything eligible. So it is self-healing — a
-dropped event strands nothing, the next one of any kind drains the queue — and no
+The event is a doorbell: the payload is ignored, the workflow loads the whole board just
+as it does on a cron tick, and picks up everything eligible. That makes it self-healing
+— a dropped event strands nothing, the next one of any kind drains the queue — and no
 `types:` list has to be got right. It also covers the implementer, whose real gate
-(board `Status` → `Scheduled`) raises only the organization-scoped `projects_v2_item`
-that repository workflows cannot subscribe to.
+(board `Status` → `Scheduled`) raises only the organization-scoped `projects_v2_item`,
+which a repository workflow cannot subscribe to.
 
-For overlapping runs, have the load job exit early if another run of the same workflow
-is already in progress. Exiting is safe for the same reason the trigger works: the
-in-flight run or the next event will pick the work up. Prefer this to a `concurrency:`
-group, which either queues runs or cancels them mid-flight — and cancelling would kill
-an agent mid-work and strand its card in a working lane.
+Overlapping runs are handled by the load job exiting early when another run of the same
+workflow is in progress, rather than by a `concurrency:` group — queuing delays work, and
+`cancel-in-progress` would kill an agent mid-work and strand its card in a working lane.
+Exiting is safe for the same reason the trigger works: the in-flight run or the next
+event picks the work up.
 
 Note: `actionlint` accepts `on: projects_v2_item:`. That is a false positive from a
 permissive event list, not evidence it fires.

--- a/docs/AUTOMATION-ARCHITECTURE.md
+++ b/docs/AUTOMATION-ARCHITECTURE.md
@@ -43,11 +43,14 @@ card there authorises writing code.
 
 ## Debounce before claiming
 
-On any non-manual trigger, the workflow polls the issue's `updatedAt` and waits until
-it has been unchanged for 5 minutes before claiming the card. Editing an issue produces
-a stream of events and updates, so without this an agent can start against a
-half-written issue or a plan still being revised. Manual `workflow_dispatch` skips the
-wait — the user picked the moment.
+On an `issues`-triggered run only, the workflow polls the issue's `updatedAt` and waits
+until it has been unchanged for 5 minutes before claiming the card. Editing an issue
+produces a stream of events, so without this an agent starts against a half-written
+issue or a plan still being revised.
+
+A schedule fires on its own clock, unrelated to when anyone is typing, and manual
+dispatch means the user picked the moment — so neither waits. The step is dormant until
+the `issues` trigger above is added.
 
 The loop is capped at six waits (30 minutes) and then proceeds with a warning rather
 than blocking forever; job timeouts allow for that on top of the agent's own run.

--- a/docs/AUTOMATION-ARCHITECTURE.md
+++ b/docs/AUTOMATION-ARCHITECTURE.md
@@ -146,3 +146,31 @@ There is no dispatch input for this, deliberately. **The board is the scoping
 mechanism.** To plan fewer issues, set Priority on fewer issues. To implement fewer,
 move fewer cards to `Scheduled`. Any out-of-band scoping input would be a second control
 surface that bypasses the board and diverges from what the board shows.
+
+## Future: trigger the planner on issue events instead of cron
+
+Setting Priority is what makes a `Backlog` card plannable, and Priority is a native
+**Issue** field — so the planner does not need to wait for a cron tick. The `issues`
+event is repository-scoped and a valid workflow trigger, and its activity types include
+`field_added` and `field_removed` for native field changes:
+
+```yaml
+on:
+  issues:
+    types: [field_added, field_removed, opened, reopened]
+```
+
+The job still loads the board as it does today, so the event is only a wake-up: the
+`Backlog` + Priority gate stays the single source of truth and an event for an
+irrelevant issue costs one fast `load-stories` run that exits with `has_work=false`.
+Worth confirming against a live event which action fires when a Priority value is
+*changed* rather than first set, before relying on the `types` list above.
+
+The implementer cannot be triggered this way. Its gate is the board `Status` moving to
+`Scheduled`, which is a Projects v2 change, and `projects_v2_item` is an
+**organization**-scoped webhook that repository workflows cannot subscribe to.
+(`actionlint` accepts `on: projects_v2_item:` — that is a false positive from a
+permissive event list, not evidence it fires.) Options there are an org webhook relaying
+to `repository_dispatch`, or simply a shorter cron: `load-stories` exits in seconds when
+nothing matches and the agent jobs are gated on `has_work`, so a 15-minute cadence costs
+almost nothing.

--- a/docs/AUTOMATION-ARCHITECTURE.md
+++ b/docs/AUTOMATION-ARCHITECTURE.md
@@ -160,17 +160,28 @@ on:
     types: [field_added, field_removed, opened, reopened]
 ```
 
-The job still loads the board as it does today, so the event is only a wake-up: the
-`Backlog` + Priority gate stays the single source of truth and an event for an
-irrelevant issue costs one fast `load-stories` run that exits with `has_work=false`.
-Worth confirming against a live event which action fires when a Priority value is
-*changed* rather than first set, before relying on the `types` list above.
+**The event is a doorbell, not a work item.** The workflow ignores the payload and
+loads the whole board exactly as it does on a cron tick, so it picks up everything
+currently eligible — not just the issue that fired. Three things follow, and they are
+the reason to do it this way:
 
-The implementer cannot be triggered this way. Its gate is the board `Status` moving to
-`Scheduled`, which is a Projects v2 change, and `projects_v2_item` is an
-**organization**-scoped webhook that repository workflows cannot subscribe to.
-(`actionlint` accepts `on: projects_v2_item:` — that is a false positive from a
-permissive event list, not evidence it fires.) Options there are an org webhook relaying
-to `repository_dispatch`, or simply a shorter cron: `load-stories` exits in seconds when
-nothing matches and the agent jobs are gated on `has_work`, so a 15-minute cadence costs
-almost nothing.
+- **Self-healing.** A dropped or missed event strands nothing. The next event of any
+  kind drains the whole queue, and cron remains as a backstop if every event is lost.
+- **The `types:` list stops being load-bearing.** Since no run depends on *which* event
+  arrived, a broader trigger set is harmless and a missing action only delays work until
+  the next event or tick. Getting `field_added` versus `edited` exactly right — and the
+  open question of which fires when a Priority value is *changed* rather than first set
+  — costs nothing to get wrong.
+- **The implementer benefits too, without a relay.** Its gate is board `Status` moving
+  to `Scheduled`, which raises `projects_v2_item` — an **organization**-scoped webhook
+  that repository workflows cannot subscribe to. (`actionlint` accepts
+  `on: projects_v2_item:`; that is a false positive from a permissive event list, not
+  evidence it fires.) But triggering the implementer on `issues` as well means any issue
+  activity in the repo wakes it and it finds the `Scheduled` card. Not instant, but
+  self-healing and free, where a relay is neither.
+
+**Prerequisite: a `concurrency:` group on both workflows.** Neither has one. Under cron
+alone, runs are hours apart and overlap is unlikely. Event-driven, several can start
+within seconds of each other, and the deterministic claim is not atomic — two runs can
+both read a card as `Scheduled` before either claims it. Adding the trigger without the
+concurrency group would produce duplicate branches and duplicate plan sections.

--- a/docs/AUTOMATION-ARCHITECTURE.md
+++ b/docs/AUTOMATION-ARCHITECTURE.md
@@ -149,39 +149,21 @@ surface that bypasses the board and diverges from what the board shows.
 
 ## Future: trigger the planner on issue events instead of cron
 
-Setting Priority is what makes a `Backlog` card plannable, and Priority is a native
-**Issue** field — so the planner does not need to wait for a cron tick. The `issues`
-event is repository-scoped and a valid workflow trigger, and its activity types include
-`field_added` and `field_removed` for native field changes:
+Add `on: issues:` — every issue activity type, no filter — to both workflows, and keep
+cron as a backstop.
 
-```yaml
-on:
-  issues:
-    types: [field_added, field_removed, opened, reopened]
-```
+The event is a doorbell: the payload is ignored, the workflow loads the whole board as
+it does on a cron tick, and picks up everything eligible. So it is self-healing — a
+dropped event strands nothing, the next one of any kind drains the queue — and no
+`types:` list has to be got right. It also covers the implementer, whose real gate
+(board `Status` → `Scheduled`) raises only the organization-scoped `projects_v2_item`
+that repository workflows cannot subscribe to.
 
-**The event is a doorbell, not a work item.** The workflow ignores the payload and
-loads the whole board exactly as it does on a cron tick, so it picks up everything
-currently eligible — not just the issue that fired. Three things follow, and they are
-the reason to do it this way:
+For overlapping runs, have the load job exit early if another run of the same workflow
+is already in progress. Exiting is safe for the same reason the trigger works: the
+in-flight run or the next event will pick the work up. Prefer this to a `concurrency:`
+group, which either queues runs or cancels them mid-flight — and cancelling would kill
+an agent mid-work and strand its card in a working lane.
 
-- **Self-healing.** A dropped or missed event strands nothing. The next event of any
-  kind drains the whole queue, and cron remains as a backstop if every event is lost.
-- **The `types:` list stops being load-bearing.** Since no run depends on *which* event
-  arrived, a broader trigger set is harmless and a missing action only delays work until
-  the next event or tick. Getting `field_added` versus `edited` exactly right — and the
-  open question of which fires when a Priority value is *changed* rather than first set
-  — costs nothing to get wrong.
-- **The implementer benefits too, without a relay.** Its gate is board `Status` moving
-  to `Scheduled`, which raises `projects_v2_item` — an **organization**-scoped webhook
-  that repository workflows cannot subscribe to. (`actionlint` accepts
-  `on: projects_v2_item:`; that is a false positive from a permissive event list, not
-  evidence it fires.) But triggering the implementer on `issues` as well means any issue
-  activity in the repo wakes it and it finds the `Scheduled` card. Not instant, but
-  self-healing and free, where a relay is neither.
-
-**Prerequisite: a `concurrency:` group on both workflows.** Neither has one. Under cron
-alone, runs are hours apart and overlap is unlikely. Event-driven, several can start
-within seconds of each other, and the deterministic claim is not atomic — two runs can
-both read a card as `Scheduled` before either claims it. Adding the trigger without the
-concurrency group would produce duplicate branches and duplicate plan sections.
+Note: `actionlint` accepts `on: projects_v2_item:`. That is a false positive from a
+permissive event list, not evidence it fires.

--- a/docs/AUTOMATION-ARCHITECTURE.md
+++ b/docs/AUTOMATION-ARCHITECTURE.md
@@ -4,33 +4,50 @@ Four pipelines drive one GitHub Projects v2 board, **Rosetta Automation Board**
 (org `griddynamics`, project 57). Board membership is the scoping mechanism: only
 issues on the board are eligible for AI work.
 
+## Status lanes
+
+| lane | meaning | moved in by | picked up by |
+|---|---|---|---|
+| `Backlog` | needs planning | repo-analysis, or the user | **planner** — only if Priority is set and not `Low` |
+| `Planning` | planner claimed it, working | planner (start) | — |
+| `Ready` | plan written, awaiting user review | planner (end) | — |
+| `Scheduled` | user authorised implementation | **the user** | **implementer** — no priority filter |
+| `In progress` | implementer claimed it, working | implementer (start) | — |
+| `In review` | PR open, awaiting user review | implementer (end) | — |
+| `Done` | done | the user | — |
+
 ```
-repo-analysis ──files issues──▶ Backlog
-                                  │
-                    (human sets Priority on the issue)
-                                  │
-                repo-plan ────────┤ Backlog + Priority set and not Low
-                                  ▼
-                            In progress   ── plan written into the issue description
-                                  │
-                        (human reviews, moves the card)
-                                  ▼
-                                Ready
-                                  │
-             repo-implement ──────┤
-                                  ▼
-                            In progress ──▶ PR opened ──▶ In review
+Backlog ─▶ Planning ─▶ Ready ─▶ Scheduled ─▶ In progress ─▶ In review ─▶ Done
+└── planner: load, claim, end ──┘└── implementer: load, claim, end ──┘
+                                ▲                                    ▲
+                          user decides                         user decides
 ```
 
 `repo-triage` is separate: it reacts to PR/issue events and does not add cards.
 
-## The two gates are human
+## Why the lanes are shaped this way
 
-- **Backlog → Ready** is the plan-approval gate. It is coding-flow phase 6
-  (`user_review_plan`) expressed on the board. No agent may make this move.
-- **PR review** is coding-flow phase 10 (`user_review_impl`).
+Each pipeline gets three lanes — one it loads from, one it claims into, one it ends
+in — and its terminal lane is never its input lane. Re-processing is therefore
+structurally impossible: a planned card cannot be re-planned, nor an implemented card
+re-implemented, unless the user moves it back.
 
-Agents never promote their own work past either gate.
+The claim into the working lane is the concurrency lock and the only visible signal
+that a pipeline is running. A crashed run parks its card in a working lane
+(`Planning` / `In progress`), which no pipeline loads — so nothing loops, and the card
+is visibly waiting for the user.
+
+Neither lane an agent loads from (`Backlog`, `Scheduled`) is one anybody moves a card
+into casually. `Scheduled` reads as a decision because that is what it is: moving a
+card there authorises writing code.
+
+## The two gates are the user's
+
+- **`Ready` → `Scheduled`** is the plan-approval gate — coding-flow phase 6
+  (`user_review_plan`) expressed on the board.
+- **`In review` → `Done`** is PR review — coding-flow phase 10 (`user_review_impl`).
+
+Agents never make either move.
 
 ## Priority
 
@@ -40,7 +57,7 @@ so the loader reads it from `Issue.issueFieldValues` over GraphQL. Reading it of
 the project item returns `None` for every card and silently plans nothing.
 
 The gate applies **only** to the planner: unset or `Low` is never planned. There is
-no priority gate on the implementer — a human moving a card to `Ready` is the
+no priority gate on the implementer — the user moving a card to `Scheduled` is the
 decision to build it. Skips are logged, never silent.
 
 ## coding-flow is split across the two runs
@@ -104,11 +121,10 @@ and the implementer holds `Bash(*)` with a PAT in the git remote URL.
 
 ## Terminal states
 
-- **In review** — PR open, waiting on a human.
-- **In progress with a `⚠️` comment** — needs a human and is picked up by no
-  pipeline. Used when an issue cannot be automated (e.g. a `.github/workflows/`
-  edit rejected because the PAT lacks the `workflow` scope). Returning such a card
-  to Backlog would re-plan it every cycle forever.
+- **`In review`** — PR open, waiting on the user.
+- **A working lane (`Planning` / `In progress`) with a `⚠️` comment** — needs the
+  user. No pipeline loads a working lane, so the card waits instead of looping. Used
+  when a run cannot complete, or when an issue cannot be automated at all.
 
 ## Pushing workflow files
 
@@ -128,5 +144,5 @@ nicely is not.
 
 There is no dispatch input for this, deliberately. **The board is the scoping
 mechanism.** To plan fewer issues, set Priority on fewer issues. To implement fewer,
-move fewer cards to `Ready`. Any out-of-band scoping input would be a second control
+move fewer cards to `Scheduled`. Any out-of-band scoping input would be a second control
 surface that bypasses the board and diverges from what the board shows.

--- a/docs/AUTOMATION-ARCHITECTURE.md
+++ b/docs/AUTOMATION-ARCHITECTURE.md
@@ -41,6 +41,17 @@ Neither lane an agent loads from (`Backlog`, `Scheduled`) is one anybody moves a
 into casually. `Scheduled` reads as a decision because that is what it is: moving a
 card there authorises writing code.
 
+## Debounce before claiming
+
+On any non-manual trigger, the workflow polls the issue's `updatedAt` and waits until
+it has been unchanged for 5 minutes before claiming the card. Editing an issue produces
+a stream of events and updates, so without this an agent can start against a
+half-written issue or a plan still being revised. Manual `workflow_dispatch` skips the
+wait — the user picked the moment.
+
+The loop is capped at six waits (30 minutes) and then proceeds with a warning rather
+than blocking forever; job timeouts allow for that on top of the agent's own run.
+
 ## The two gates are the user's
 
 - **`Ready` → `Scheduled`** is the plan-approval gate — coding-flow phase 6


### PR DESCRIPTION
Follow-up to #182. Reworks the board state machine so neither pipeline can re-process its own output, and moves claiming out of the agent.

## The defect

The planner's terminal lane was reachable from its own input lane, so a card that was planned but not moved on got re-planned every cycle. Priority is `Urgent` on some cards, so that loop burned a full agent run per tick indefinitely.

## The board now has seven lanes

| lane | meaning | moved in by | picked up by |
|---|---|---|---|
| `Backlog` | needs planning | repo-analysis, or the user | **planner** — only if Priority is set and not `Low` |
| `Planning` | planner claimed it, working | planner workflow (start) | — |
| `Ready` | plan written, awaiting user review | planner agent (end) | — |
| `Scheduled` | user authorised implementation | **the user** | **implementer** — no priority filter |
| `In progress` | implementer claimed it, working | implementer workflow (start) | — |
| `In review` | PR open, awaiting user review | implementer agent (end) | — |
| `Done` | done | the user | — |

Each pipeline loads one lane, claims into a second, ends in a third. A terminal lane is never an input lane, so re-processing is structurally impossible rather than prevented by a claim that might not happen. A crashed run parks its card in a working lane that no pipeline loads — nothing loops, and the card is visibly waiting for a human.

Neither lane an agent loads from (`Backlog`, `Scheduled`) is one anyone moves a card into casually. `Scheduled` reads as a decision because that is what it is.

The user's two gates are single moves: `Ready` → `Scheduled` approves the plan (coding-flow phase 6), `In review` → `Done` accepts the PR (phase 10). Agents make neither.

## Claiming is deterministic

The workflow moves the card into the working lane and posts the "started" comment before invoking `claude-code-action`. Neither action needs judgement, so neither costs an agent turn.

- `jq -er` fails the step if the board lacks the option, rather than letting the agent run against a lane that does not exist.
- Option ids reach the shell through `env:` vars, not `${{ }}` interpolation into `run:` — that is a script-injection path and the JSON comes from an upstream job output.
- On failure, a step comments the run URL, names the lane the card is parked in, and says how to retry.

Terminal moves stay with the agent on purpose: `Ready` is valid only when a plan actually exists (not when the issue turns out non-implementable), and `In review` only once a PR exists. The workflow cannot tell those apart — the guard only knows *something* mutated.

## Verification

- 26 unit tests pass, including new ones pinning that working lanes (`Planning`, `In progress`) and terminal lanes (`Ready`, `In review`) are picked up by nothing — the property that makes looping impossible
- `actionlint` clean on all workflows
- board confirmed carrying all seven options in order
- live loader run against project 57 returns the expected empty matrices with the six Backlog cards skipped on priority, logged with reasons

## Note for reviewers

Existing cards were deliberately not migrated (nothing is in production use yet). #170/#171/#179 sit at `In progress` and #175/#180 at `In review`; all are inert until moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)