### PR TITLE
#176 MCP CI/publish/docker workflows missing requirements.txt in path filters

### DIFF
--- a/.github/workflows/ci-rosetta-mcp.yml
+++ b/.github/workflows/ci-rosetta-mcp.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - 'src/rosetta-mcp-server/**'
+      - 'requirements.txt'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-rosetta-mcp.yml
+++ b/.github/workflows/publish-rosetta-mcp.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'src/rosetta-mcp-server/**'
+      - 'requirements.txt'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/rosetta-mcp-dockerhub.yaml
+++ b/.github/workflows/rosetta-mcp-dockerhub.yaml
@@ -10,6 +10,7 @@ on:
       - 'src/rosetta-mcp-server/pyproject.toml'
       - '.github/workflows/rosetta-mcp-dockerhub.yaml'
       - 'src/rosetta-mcp-server/Dockerfile'
+      - 'requirements.txt'
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #176

## Summary
- Add `requirements.txt` to `pull_request.paths` in `ci-rosetta-mcp.yml`
- Add `requirements.txt` to `push.paths` in `publish-rosetta-mcp.yml`
- Add `requirements.txt` to `push.paths` in `rosetta-mcp-dockerhub.yaml`

Mirrors the existing pattern already used by `ci-rosetta-cli.yml` / `publish-rosetta-cli.yml`. Previously, a `requirements.txt`-only edit (e.g. touching the `-e ./src/rosetta-mcp-server[dev,redis]` line or the mypy pin used by `validate-types.sh`) silently skipped MCP CI, publish, and Docker build/push while still triggering CLI CI/publish.

## Testing notes
- Validated YAML syntax of all three modified files via `python -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))"`.
- Confirmed diff is exactly one added line per file (`git diff --stat`), no other content changed.
- No unit tests apply to workflow YAML path filters; acceptance signal is that a follow-up PR touching only `requirements.txt` triggers these three workflows in the Checks tab.

## Assumptions
None — mechanical change with an exact precedent already in the repo.