### PR TITLE
#177 [ROSETTA] Add concurrency groups to PR-triggered CI workflows to cancel stale runs

### DIFF
--- a/.github/workflows/ci-curiocity.yml
+++ b/.github/workflows/ci-curiocity.yml
@@ -10,6 +10,10 @@ on:
       - 'src/curiocity/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-rosetta-cli.yml
+++ b/.github/workflows/ci-rosetta-cli.yml
@@ -11,6 +11,10 @@ on:
       - 'requirements.txt'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-rosetta-hooks.yml
+++ b/.github/workflows/ci-rosetta-hooks.yml
@@ -9,6 +9,10 @@ on:
       - 'src/hooks/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-rosetta-mcp.yml
+++ b/.github/workflows/ci-rosetta-mcp.yml
@@ -10,6 +10,10 @@ on:
       - 'src/rosetta-mcp-server/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-rosettify-plugins.yml
+++ b/.github/workflows/ci-rosettify-plugins.yml
@@ -10,6 +10,10 @@ on:
       - 'src/rosettify-plugins/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-rosettify-prompts.yml
+++ b/.github/workflows/ci-rosettify-prompts.yml
@@ -10,6 +10,10 @@ on:
       - 'src/rosettify-prompts/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-rosettify.yml
+++ b/.github/workflows/ci-rosettify.yml
@@ -9,6 +9,10 @@ on:
       - 'src/rosettify/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #177

## Summary
- Added a top-level `concurrency:` block to each of the 7 PR-triggered CI workflows that lacked one:
  - `.github/workflows/ci-curiocity.yml`
  - `.github/workflows/ci-rosetta-cli.yml`
  - `.github/workflows/ci-rosetta-hooks.yml`
  - `.github/workflows/ci-rosetta-mcp.yml`
  - `.github/workflows/ci-rosettify-plugins.yml`
  - `.github/workflows/ci-rosettify-prompts.yml`
  - `.github/workflows/ci-rosettify.yml`
- Each insertion is identical: `group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`, placed after `workflow_dispatch:` and before `jobs:`, matching the existing pattern in `pages.yml`.
- No changes to `on:`, `jobs:`, permissions, or any step in any of the 7 files — strictly additive.
- Out of scope (untouched, per the plan): `pages.yml` (already has the pattern), `codeql.yml`, `e2e-testing.yml`, `validate-prompts.yml`, `validate-test-cases.yml`, `repo-plan.yml`, `repo-implement.yml`, `repo-triage.yml`.

## Testing notes
- This is CI configuration, not application code — no unit tests apply.
- Validated all 7 modified files parse as valid YAML (`yaml.safe_load`).
- Functional validation happens naturally on this PR itself: pushing a second commit here should show the first in-flight run for each touched workflow as "Canceled" in the Actions tab while the new run proceeds. Reviewer: please check the Actions tab on a follow-up push rather than expecting a test file.

## Assumptions
- None — this is a mechanical, well-isolated change following the exact pattern already present in `pages.yml`, as specified in the issue's approved plan.