### PR TITLE
#179 [ROSETTA] QA/external-lib workflow docs use RefSrc/ instead of canonical lowercase refsrc/

### DIFF
--- a/docs/manual-tests/api-aqa-flow.md
+++ b/docs/manual-tests/api-aqa-flow.md
@@ -13,14 +13,14 @@ use). UI-AQA uses the same two.
 
 - [ ] Rosetta plugin installed and active -- exercise the workflow via the installed plugin (plugin mode), not the raw r3 instructions
 - [ ] Working dir lets you write under `plans/` and `agents/TEMP/`
-- [ ] Sample backend repo at `RefSrc/<project>/` **or** a Swagger URL handy
+- [ ] Sample backend repo at `refsrc/<project>/` **or** a Swagger URL handy
 - [ ] **External-system auth is optional** -- see *Auth-free / mock testing* below. For a full real run: the configured TMS / Wiki / Issue Tracker integrations authenticated (e.g. TestRail and Atlassian MCPs).
 
 ## Auth-free / mock testing
 
 You do **not** need real TMS/Wiki/Issue Tracker credentials to test this flow. The `data-collection` bindings only ever make *real* integration calls or stop with a gap -- they never fabricate. Two ways to run auth-free:
 
-- **Mode A: source out-of-scope / provided (no integration call).** In `plans/api-aqa-{IDENTIFIER}/api-aqa-project-config.md` leave the in-scope keys unset (`tms_base_url`, `wiki_base_url` → `N/A`). Phase 1 then resolves **`SKIPPED_NO_CONFIG`**, records the gap, and proceeds on what you supply directly (paste case fields / use the direct-description trigger, or a Swagger URL/`RefSrc` path for the API contract). Validates degradation + the whole downstream pipeline on your canned input. *Caveat:* the bindings have no "provided-inline retrieval" path, so if you **do** set an in-scope key, Phase 1 will attempt the real integration and stop on auth failure.
+- **Mode A: source out-of-scope / provided (no integration call).** In `plans/api-aqa-{IDENTIFIER}/api-aqa-project-config.md` leave the in-scope keys unset (`tms_base_url`, `wiki_base_url` → `N/A`). Phase 1 then resolves **`SKIPPED_NO_CONFIG`**, records the gap, and proceeds on what you supply directly (paste case fields / use the direct-description trigger, or a Swagger URL/`refsrc` path for the API contract). Validates degradation + the whole downstream pipeline on your canned input. *Caveat:* the bindings have no "provided-inline retrieval" path, so if you **do** set an in-scope key, Phase 1 will attempt the real integration and stop on auth failure.
 - **Mode B: stub integration (canned data).** Point the configured TMS/Wiki integration at a local stub that answers the capability calls (get issue / get page / get case, etc.) with fixture JSON. The binding treats the fixtures like a real integration, running the full extract → normalize → redact → write path with zero real auth. Guardrails permit this (*"User can override (mocked data)"*).
 
 > What Mode A actually validates: the **degradation** path (gap/skip, no fabrication), not the real data-pull. Use Mode B to exercise the pull logic without credentials.
@@ -32,13 +32,13 @@ Write backend API tests for TC-1234.
 Swagger: https://api.example.com/swagger.json
 ```
 ```
-Automate backend tests for PROJ-123 with Swagger from RefSrc/my-backend/docs/openapi.json
+Automate backend tests for PROJ-123 with Swagger from refsrc/my-backend/docs/openapi.json
 ```
 ```
 Create API tests for the user registration endpoint (no ticket, direct description).
 ```
 ```
-Generate API tests for POST /orders and GET /orders/{id} from RefSrc/orders-svc/. TestRail suite: S-42.
+Generate API tests for POST /orders and GET /orders/{id} from refsrc/orders-svc/. TestRail suite: S-42.
 ```
 ```
 Write contract tests for the auth endpoints (login / refresh / logout). Swagger: https://api.example.com/v2/openapi.yaml; Jira: PROJ-789.

--- a/docs/web/docs/api-aqa-flow.md
+++ b/docs/web/docs/api-aqa-flow.md
@@ -32,7 +32,7 @@ This is a strict sequential workflow (phases 0–7). Phases build on each other,
 Prepare the inputs this workflow explicitly depends on:
 
 - A test case reference: TestRail ID, Jira ticket key/URL, or a direct description of the endpoints under test.
-- A Swagger/OpenAPI spec URL or file path, or a backend source path with route definitions (e.g. `RefSrc/my-backend/` or `src/`).
+- A Swagger/OpenAPI spec URL or file path, or a backend source path with route definitions (e.g. `refsrc/my-backend/` or `src/`).
 - Access to the repository's existing API tests, helpers, and conventions.
 - For first runs: answers for the config interview — document storage, spec availability and format, test-case source, test framework, auth mechanism (described as scheme + source, never literal credentials).
 - If TestRail/Jira/Confluence are in scope: the corresponding MCP access.
@@ -48,7 +48,7 @@ Typical prompts:
 ```
 
 ```text
-/api-aqa-flow Automate backend tests for PROJ-123 with Swagger from RefSrc/my-backend/docs/openapi.json
+/api-aqa-flow Automate backend tests for PROJ-123 with Swagger from refsrc/my-backend/docs/openapi.json
 ```
 
 ```text

--- a/docs/web/docs/configuration.md
+++ b/docs/web/docs/configuration.md
@@ -198,7 +198,7 @@ Setup actions:
 - Initialize Rosetta (see [Quick Start](/rosetta/docs/quickstart/)).
 
 <details markdown="1">
-<summary><b>Detailed examples what should be in RefSrc folder</b></summary>
+<summary><b>Detailed examples what should be in refsrc folder</b></summary>
 
 1. Example what integration or e2e testing repository needs:
 

--- a/instructions/r2/core/workflows/aqa-flow-code-analysis.md
+++ b/instructions/r2/core/workflows/aqa-flow-code-analysis.md
@@ -81,11 +81,11 @@ Understand existing test architecture, identify reusable components, and determi
 **Actions**:
 1. Check if frontend source code is available:
    ```
-   Use: Glob to check for RefSrc/tools-st-frontend/
+   Use: Glob to check for refsrc/tools-st-frontend/
    ```
 2. If frontend code exists, analyze UI structure:
    - Search for React components related to the feature under test
-   - Identify component file structure in `RefSrc/tools-st-frontend/src/`
+   - Identify component file structure in `refsrc/tools-st-frontend/src/`
    - Note component props, interfaces, and data-testid attributes
    - Document UI flow and component hierarchy
    - Identify API calls and data models used
@@ -97,13 +97,13 @@ Understand existing test architecture, identify reusable components, and determi
    ```markdown
    ### Frontend Code Analysis
    
-   #### Component: DashboardComponent (RefSrc/tools-st-frontend/src/features/dashboard/Dashboard.tsx)
+   #### Component: DashboardComponent (refsrc/tools-st-frontend/src/features/dashboard/Dashboard.tsx)
    - data-testid attributes: "welcome-message", "dashboard-title"
    - Props: { userName: string, notifications: number }
    - API calls: fetchDashboardData()
    - Related components: NotificationBell, UserProfile
    
-   #### Component: SettingsPage (RefSrc/tools-st-frontend/src/features/settings/SettingsPage.tsx)
+   #### Component: SettingsPage (refsrc/tools-st-frontend/src/features/settings/SettingsPage.tsx)
    - data-testid attributes: "email-input", "save-button"
    - Form fields: email, notifications, preferences
    ```
@@ -236,7 +236,7 @@ Understand existing test architecture, identify reusable components, and determi
    - Naming Convention: [Pattern]
    
    ### Frontend Code Analysis (if available)
-   - Frontend Source: RefSrc/tools-st-frontend/
+   - Frontend Source: refsrc/tools-st-frontend/
    - Components Analyzed: [List]
    - Available data-testid attributes: [List]
    - Component Props: [Relevant props]

--- a/instructions/r2/core/workflows/external-lib-flow.md
+++ b/instructions/r2/core/workflows/external-lib-flow.md
@@ -11,14 +11,14 @@ baseSchema: docs/schemas/workflow.md
 
 - Purpose: Onboard AI to external codebase for usage understanding
 - Tool: Repomix MCP to package codebase (compressed XML)
-- Target: Two documents in RefSrc folder and in Rosetta
+- Target: Two documents in refsrc folder and in Rosetta
   1. File: `{project-name}.xml` (compressed codebase, unmodified Repomix output)
   2. File: `{project-name}-onboarding.md` (brief Learning Flow with reference)
 - Files involved: Project path, README, package files for auto-detection
 - MUST generate brief Learning Flow (3-5 words per step, max 20 lines)
 - MUST use compressed XML (Tree-sitter) for small output
 - Onboarding document MUST specify KB title and search instructions
-- Update ARCHITECTURE.md based on template `MUST use RefSrc/{project-name}.xml and RefSrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
+- Update ARCHITECTURE.md based on template `MUST use refsrc/{project-name}.xml and refsrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
 
 ## Onboarding Flow
 

--- a/instructions/r3/core/skills/qa-structure/assets/api-aqa-config-interview.md
+++ b/instructions/r3/core/skills/qa-structure/assets/api-aqa-config-interview.md
@@ -36,8 +36,8 @@ To automate backend API tests effectively, I need the following project details:
    - How should tests authenticate? (test credentials, mock auth, service account)
    - ⚠️ Do NOT paste literal credential values (tokens, passwords, API keys) — describe the **mechanism + source** only (e.g. "Bearer JWT from AuthHelper; credentials in env var `AUTH_TOKEN`").
 
-6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md RefSrc references):
-   - In RefSrc/ folder (provide project name, e.g., RefSrc/my-backend/)
+6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md refsrc references):
+   - In refsrc/ folder (provide project name, e.g., refsrc/my-backend/)
    - In the current workspace (provide path, e.g., src/, backend/)
    - Not available (I will work from Swagger/docs only)
 

--- a/instructions/r3/core/skills/qa-structure/references/config-schema.md
+++ b/instructions/r3/core/skills/qa-structure/references/config-schema.md
@@ -15,7 +15,7 @@ The project-config-loading phase completes only when every required key below ho
 | `Wiki / Document Storage` -- `wiki_base_url` | data-collection phase (scope detection + access) | Base URL or `N/A -- wiki_provider: <none/local>` |
 | `API Specification` -- `swagger_url` (or path) | api-spec-analysis phase | URL/path, or `N/A -- no Swagger spec available; code-based analysis will run` |
 | `API Specification` -- `spec_format` | api-spec-analysis phase | One of: `OpenAPI 3.x` / `Swagger 2.0` / `N/A` |
-| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `RefSrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
+| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `refsrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
 | `Test Case Management` -- `tms_provider` | data-collection phase (branch selector) | Provider name (e.g. `testrail` / `jira` / `confluence`) or `manual` / `other` |
 | `Test Case Management` -- `tms_base_url` | data-collection phase (provider access) | Base URL or `N/A -- tms_provider: manual` |
 | `Test Case Management` -- `project_id` / `suite_id` | data-collection phase (provider-specific run identifiers; TestRail project/suite is the canonical example) | IDs, or `N/A -- tms_provider: <value without project/suite IDs>` |

--- a/instructions/r3/core/workflows/api-aqa-flow-api-spec-analysis.md
+++ b/instructions/r3/core/workflows/api-aqa-flow-api-spec-analysis.md
@@ -37,7 +37,7 @@ The phase supplies the skill two required inputs; the skill GATEs on both before
 
 <determine_spec_source step="2.1">
 
-Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `RefSrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `RefSrc/{project-name}/docs/` to understand API architecture before searching source code.
+Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `refsrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `refsrc/{project-name}/docs/` to understand API architecture before searching source code.
 
 Determine spec source in order:
 

--- a/instructions/r3/core/workflows/api-aqa-flow-data-collection.md
+++ b/instructions/r3/core/workflows/api-aqa-flow-data-collection.md
@@ -35,7 +35,7 @@ This phase owns the raw-data aggregation artifact `plans/api-aqa-{IDENTIFIER}/ra
 - **Test Case Data** — from `data-collection` (role `TMS`, resolved provider); ≥1 test-case source required.
 - **Documentation / Wiki** — from `data-collection` (role `Wiki`, resolved provider) via step 1.2b when scoped; else the `SKIPPED_NO_CONFIG` outcome row (per `<wiki_outcomes>`).
 - **Existing Test Patterns** — from `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis, via `reverse-engineering`); framework, HTTP client, structure/assertion/auth conventions, reusable utilities. Record env-file **path + variable names only**, never literal values.
-- **Backend Source Code Analysis** — backend path from config or discoverable `RefSrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
+- **Backend Source Code Analysis** — backend path from config or discoverable `refsrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
 - **API Endpoints Identified** — every row has Method + Source populated; partial rows tagged as gaps.
 - **Data Collection Summary** — counts + gap notes; a delegated-skill stop is recorded verbatim as `Gap: <skill> stopped — <message>`, never fabricated over.
 

--- a/instructions/r3/core/workflows/external-lib-flow.md
+++ b/instructions/r3/core/workflows/external-lib-flow.md
@@ -11,14 +11,14 @@ baseSchema: docs/schemas/workflow.md
 
 - Purpose: Onboard AI to external codebase for usage understanding
 - Tool: Repomix MCP to package codebase (compressed XML)
-- Target: Two documents in RefSrc folder and in Rosetta
+- Target: Two documents in refsrc folder and in Rosetta
   1. File: `{project-name}.xml` (compressed codebase, unmodified Repomix output)
   2. File: `{project-name}-onboarding.md` (brief Learning Flow with reference)
 - Files involved: Project path, README, package files for auto-detection
 - MUST generate brief Learning Flow (3-5 words per step, max 20 lines)
 - MUST use compressed XML (Tree-sitter) for small output
 - Onboarding document MUST specify KB title and search instructions
-- Update ARCHITECTURE.md based on template `MUST use RefSrc/{project-name}.xml and RefSrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
+- Update ARCHITECTURE.md based on template `MUST use refsrc/{project-name}.xml and refsrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
 - Workflow state MUST be saved to `agents/TEMP/<FEATURE>/external-lib-flow-state.md` file.
 
 ## Onboarding Flow

--- a/instructions/r3/core/workflows/ui-aqa-flow-code-analysis.md
+++ b/instructions/r3/core/workflows/ui-aqa-flow-code-analysis.md
@@ -32,7 +32,7 @@ The phase supplies these paths to the skill; defaults apply when not configured:
 | Project description | `project_description.md` (repo root) | Framework, language, structure, coding standards — read when present |
 | Project context | configured paths; canonical `docs/CONTEXT.md`, `docs/ARCHITECTURE.md`, `agents/IMPLEMENTATION.md` | Architecture and conventions — read when present |
 | Optional user instructions | `agents/user-instructions/` | Test guidelines, custom matchers, style |
-| Optional frontend source | repo-specific (e.g. `RefSrc/<repo>/`) | Component files for selector / test-id discovery |
+| Optional frontend source | repo-specific (e.g. `refsrc/<repo>/`) | Component files for selector / test-id discovery |
 | Output | `plans/ui-aqa-<test-name>/code-analysis.md` | The report (this phase's contract, below) |
 
 **Input GATE.** Before analysis: test plan exists and is non-empty; `project_description.md`, `gain.json`, or one authoritative project-context file exists; codebase root is readable. Resolve file locations from `gain.json`, falling back to the canonical paths above. Any miss → stop Phase 3, record the gap in `ui-aqa-state.md`, ask the user. Do NOT infer framework from incidental file extensions.
@@ -57,7 +57,7 @@ After writing the report, update the test plan's `## Code Analysis` section with
 2. USE SKILL `reverse-engineering` and USE SKILL `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis) with the phase-supplied bindings: inputs + defaults = `<input_contract>`; report structure + test-location rule = the skill's code-analysis report template; output path = `plans/ui-aqa-<test-name>/code-analysis.md`. USE SKILL `sensitive-data` before writing.
 3. **Conditional-input else-paths:**
    - If `agents/user-instructions/` is **absent or empty**: record `not available — see Coverage section` in report section 2 and `not available` in section 9; Phase 3 **continues**, does not stop.
-   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `RefSrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
+   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `refsrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
 4. Do not fabricate framework, page objects, or pass/fail data. Honor the read-only scope (`<workflow_context>`).
 5. **Post-analysis verification:** confirm the report exists with every section from the code-analysis report template and the test plan's `## Code Analysis` summary is added. If missing/incomplete: re-run once with the same bindings; if still failing, stop Phase 3, record `Phase 3 blocked: code-analysis report not produced/incomplete` in `agents/TEMP/<FEATURE>/ui-aqa-state.md`, ask the user.
 </execute_analysis>

--- a/plugins/core-antigravity/skills/api-aqa-flow/phases/api-aqa-flow-api-spec-analysis.md
+++ b/plugins/core-antigravity/skills/api-aqa-flow/phases/api-aqa-flow-api-spec-analysis.md
@@ -28,7 +28,7 @@ The phase supplies the skill two required inputs; the skill GATEs on both before
 
 <determine_spec_source step="2.1">
 
-Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `RefSrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `RefSrc/{project-name}/docs/` to understand API architecture before searching source code.
+Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `refsrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `refsrc/{project-name}/docs/` to understand API architecture before searching source code.
 
 Determine spec source in order:
 

--- a/plugins/core-antigravity/skills/api-aqa-flow/phases/api-aqa-flow-data-collection.md
+++ b/plugins/core-antigravity/skills/api-aqa-flow/phases/api-aqa-flow-data-collection.md
@@ -26,7 +26,7 @@ This phase owns the raw-data aggregation artifact `plans/api-aqa-{IDENTIFIER}/ra
 - **Test Case Data** — from `data-collection` (role `TMS`, resolved provider); ≥1 test-case source required.
 - **Documentation / Wiki** — from `data-collection` (role `Wiki`, resolved provider) via step 1.2b when scoped; else the `SKIPPED_NO_CONFIG` outcome row (per `<wiki_outcomes>`).
 - **Existing Test Patterns** — from `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis, via `reverse-engineering`); framework, HTTP client, structure/assertion/auth conventions, reusable utilities. Record env-file **path + variable names only**, never literal values.
-- **Backend Source Code Analysis** — backend path from config or discoverable `RefSrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
+- **Backend Source Code Analysis** — backend path from config or discoverable `refsrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
 - **API Endpoints Identified** — every row has Method + Source populated; partial rows tagged as gaps.
 - **Data Collection Summary** — counts + gap notes; a delegated-skill stop is recorded verbatim as `Gap: <skill> stopped — <message>`, never fabricated over.
 

--- a/plugins/core-antigravity/skills/external-lib-flow/SKILL.md
+++ b/plugins/core-antigravity/skills/external-lib-flow/SKILL.md
@@ -9,14 +9,14 @@ description: "Workflow for onboarding an external private library so AI can use 
 
 - Purpose: Onboard AI to external codebase for usage understanding
 - Tool: Repomix MCP to package codebase (compressed XML)
-- Target: Two documents in RefSrc folder and in Rosetta
+- Target: Two documents in refsrc folder and in Rosetta
   1. File: `{project-name}.xml` (compressed codebase, unmodified Repomix output)
   2. File: `{project-name}-onboarding.md` (brief Learning Flow with reference)
 - Files involved: Project path, README, package files for auto-detection
 - MUST generate brief Learning Flow (3-5 words per step, max 20 lines)
 - MUST use compressed XML (Tree-sitter) for small output
 - Onboarding document MUST specify KB title and search instructions
-- Update ARCHITECTURE.md based on template `MUST use RefSrc/{project-name}.xml and RefSrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
+- Update ARCHITECTURE.md based on template `MUST use refsrc/{project-name}.xml and refsrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
 - Workflow state MUST be saved to `agents/TEMP/<FEATURE>/external-lib-flow-state.md` file.
 
 ## Onboarding Flow

--- a/plugins/core-antigravity/skills/qa-structure/assets/api-aqa-config-interview.md
+++ b/plugins/core-antigravity/skills/qa-structure/assets/api-aqa-config-interview.md
@@ -36,8 +36,8 @@ To automate backend API tests effectively, I need the following project details:
    - How should tests authenticate? (test credentials, mock auth, service account)
    - ⚠️ Do NOT paste literal credential values (tokens, passwords, API keys) — describe the **mechanism + source** only (e.g. "Bearer JWT from AuthHelper; credentials in env var `AUTH_TOKEN`").
 
-6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md RefSrc references):
-   - In RefSrc/ folder (provide project name, e.g., RefSrc/my-backend/)
+6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md refsrc references):
+   - In refsrc/ folder (provide project name, e.g., refsrc/my-backend/)
    - In the current workspace (provide path, e.g., src/, backend/)
    - Not available (I will work from Swagger/docs only)
 

--- a/plugins/core-antigravity/skills/qa-structure/references/config-schema.md
+++ b/plugins/core-antigravity/skills/qa-structure/references/config-schema.md
@@ -15,7 +15,7 @@ The project-config-loading phase completes only when every required key below ho
 | `Wiki / Document Storage` -- `wiki_base_url` | data-collection phase (scope detection + access) | Base URL or `N/A -- wiki_provider: <none/local>` |
 | `API Specification` -- `swagger_url` (or path) | api-spec-analysis phase | URL/path, or `N/A -- no Swagger spec available; code-based analysis will run` |
 | `API Specification` -- `spec_format` | api-spec-analysis phase | One of: `OpenAPI 3.x` / `Swagger 2.0` / `N/A` |
-| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `RefSrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
+| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `refsrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
 | `Test Case Management` -- `tms_provider` | data-collection phase (branch selector) | Provider name (e.g. `testrail` / `jira` / `confluence`) or `manual` / `other` |
 | `Test Case Management` -- `tms_base_url` | data-collection phase (provider access) | Base URL or `N/A -- tms_provider: manual` |
 | `Test Case Management` -- `project_id` / `suite_id` | data-collection phase (provider-specific run identifiers; TestRail project/suite is the canonical example) | IDs, or `N/A -- tms_provider: <value without project/suite IDs>` |

--- a/plugins/core-antigravity/skills/ui-aqa-flow/phases/ui-aqa-flow-code-analysis.md
+++ b/plugins/core-antigravity/skills/ui-aqa-flow/phases/ui-aqa-flow-code-analysis.md
@@ -23,7 +23,7 @@ The phase supplies these paths to the skill; defaults apply when not configured:
 | Project description | `project_description.md` (repo root) | Framework, language, structure, coding standards — read when present |
 | Project context | configured paths; canonical `docs/CONTEXT.md`, `docs/ARCHITECTURE.md`, `agents/IMPLEMENTATION.md` | Architecture and conventions — read when present |
 | Optional user instructions | `agents/user-instructions/` | Test guidelines, custom matchers, style |
-| Optional frontend source | repo-specific (e.g. `RefSrc/<repo>/`) | Component files for selector / test-id discovery |
+| Optional frontend source | repo-specific (e.g. `refsrc/<repo>/`) | Component files for selector / test-id discovery |
 | Output | `plans/ui-aqa-<test-name>/code-analysis.md` | The report (this phase's contract, below) |
 
 **Input GATE.** Before analysis: test plan exists and is non-empty; `project_description.md`, `gain.json`, or one authoritative project-context file exists; codebase root is readable. Resolve file locations from `gain.json`, falling back to the canonical paths above. Any miss → stop Phase 3, record the gap in `ui-aqa-state.md`, ask the user. Do NOT infer framework from incidental file extensions.
@@ -48,7 +48,7 @@ After writing the report, update the test plan's `## Code Analysis` section with
 2. USE SKILL `reverse-engineering` and USE SKILL `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis) with the phase-supplied bindings: inputs + defaults = `<input_contract>`; report structure + test-location rule = the skill's code-analysis report template; output path = `plans/ui-aqa-<test-name>/code-analysis.md`. USE SKILL `sensitive-data` before writing.
 3. **Conditional-input else-paths:**
    - If `agents/user-instructions/` is **absent or empty**: record `not available — see Coverage section` in report section 2 and `not available` in section 9; Phase 3 **continues**, does not stop.
-   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `RefSrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
+   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `refsrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
 4. Do not fabricate framework, page objects, or pass/fail data. Honor the read-only scope (`<workflow_context>`).
 5. **Post-analysis verification:** confirm the report exists with every section from the code-analysis report template and the test plan's `## Code Analysis` summary is added. If missing/incomplete: re-run once with the same bindings; if still failing, stop Phase 3, record `Phase 3 blocked: code-analysis report not produced/incomplete` in `agents/TEMP/<FEATURE>/ui-aqa-state.md`, ask the user.
 </execute_analysis>

--- a/plugins/core-claude/skills/qa-structure/assets/api-aqa-config-interview.md
+++ b/plugins/core-claude/skills/qa-structure/assets/api-aqa-config-interview.md
@@ -36,8 +36,8 @@ To automate backend API tests effectively, I need the following project details:
    - How should tests authenticate? (test credentials, mock auth, service account)
    - ⚠️ Do NOT paste literal credential values (tokens, passwords, API keys) — describe the **mechanism + source** only (e.g. "Bearer JWT from AuthHelper; credentials in env var `AUTH_TOKEN`").
 
-6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md RefSrc references):
-   - In RefSrc/ folder (provide project name, e.g., RefSrc/my-backend/)
+6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md refsrc references):
+   - In refsrc/ folder (provide project name, e.g., refsrc/my-backend/)
    - In the current workspace (provide path, e.g., src/, backend/)
    - Not available (I will work from Swagger/docs only)
 

--- a/plugins/core-claude/skills/qa-structure/references/config-schema.md
+++ b/plugins/core-claude/skills/qa-structure/references/config-schema.md
@@ -15,7 +15,7 @@ The project-config-loading phase completes only when every required key below ho
 | `Wiki / Document Storage` -- `wiki_base_url` | data-collection phase (scope detection + access) | Base URL or `N/A -- wiki_provider: <none/local>` |
 | `API Specification` -- `swagger_url` (or path) | api-spec-analysis phase | URL/path, or `N/A -- no Swagger spec available; code-based analysis will run` |
 | `API Specification` -- `spec_format` | api-spec-analysis phase | One of: `OpenAPI 3.x` / `Swagger 2.0` / `N/A` |
-| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `RefSrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
+| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `refsrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
 | `Test Case Management` -- `tms_provider` | data-collection phase (branch selector) | Provider name (e.g. `testrail` / `jira` / `confluence`) or `manual` / `other` |
 | `Test Case Management` -- `tms_base_url` | data-collection phase (provider access) | Base URL or `N/A -- tms_provider: manual` |
 | `Test Case Management` -- `project_id` / `suite_id` | data-collection phase (provider-specific run identifiers; TestRail project/suite is the canonical example) | IDs, or `N/A -- tms_provider: <value without project/suite IDs>` |

--- a/plugins/core-claude/workflows/api-aqa-flow-api-spec-analysis.md
+++ b/plugins/core-claude/workflows/api-aqa-flow-api-spec-analysis.md
@@ -37,7 +37,7 @@ The phase supplies the skill two required inputs; the skill GATEs on both before
 
 <determine_spec_source step="2.1">
 
-Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `RefSrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `RefSrc/{project-name}/docs/` to understand API architecture before searching source code.
+Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `refsrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `refsrc/{project-name}/docs/` to understand API architecture before searching source code.
 
 Determine spec source in order:
 

--- a/plugins/core-claude/workflows/api-aqa-flow-data-collection.md
+++ b/plugins/core-claude/workflows/api-aqa-flow-data-collection.md
@@ -35,7 +35,7 @@ This phase owns the raw-data aggregation artifact `plans/api-aqa-{IDENTIFIER}/ra
 - **Test Case Data** — from `data-collection` (role `TMS`, resolved provider); ≥1 test-case source required.
 - **Documentation / Wiki** — from `data-collection` (role `Wiki`, resolved provider) via step 1.2b when scoped; else the `SKIPPED_NO_CONFIG` outcome row (per `<wiki_outcomes>`).
 - **Existing Test Patterns** — from `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis, via `reverse-engineering`); framework, HTTP client, structure/assertion/auth conventions, reusable utilities. Record env-file **path + variable names only**, never literal values.
-- **Backend Source Code Analysis** — backend path from config or discoverable `RefSrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
+- **Backend Source Code Analysis** — backend path from config or discoverable `refsrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
 - **API Endpoints Identified** — every row has Method + Source populated; partial rows tagged as gaps.
 - **Data Collection Summary** — counts + gap notes; a delegated-skill stop is recorded verbatim as `Gap: <skill> stopped — <message>`, never fabricated over.
 

--- a/plugins/core-claude/workflows/external-lib-flow.md
+++ b/plugins/core-claude/workflows/external-lib-flow.md
@@ -11,14 +11,14 @@ baseSchema: docs/schemas/workflow.md
 
 - Purpose: Onboard AI to external codebase for usage understanding
 - Tool: Repomix MCP to package codebase (compressed XML)
-- Target: Two documents in RefSrc folder and in Rosetta
+- Target: Two documents in refsrc folder and in Rosetta
   1. File: `{project-name}.xml` (compressed codebase, unmodified Repomix output)
   2. File: `{project-name}-onboarding.md` (brief Learning Flow with reference)
 - Files involved: Project path, README, package files for auto-detection
 - MUST generate brief Learning Flow (3-5 words per step, max 20 lines)
 - MUST use compressed XML (Tree-sitter) for small output
 - Onboarding document MUST specify KB title and search instructions
-- Update ARCHITECTURE.md based on template `MUST use RefSrc/{project-name}.xml and RefSrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
+- Update ARCHITECTURE.md based on template `MUST use refsrc/{project-name}.xml and refsrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
 - Workflow state MUST be saved to `agents/TEMP/<FEATURE>/external-lib-flow-state.md` file.
 
 ## Onboarding Flow

--- a/plugins/core-claude/workflows/ui-aqa-flow-code-analysis.md
+++ b/plugins/core-claude/workflows/ui-aqa-flow-code-analysis.md
@@ -32,7 +32,7 @@ The phase supplies these paths to the skill; defaults apply when not configured:
 | Project description | `project_description.md` (repo root) | Framework, language, structure, coding standards — read when present |
 | Project context | configured paths; canonical `docs/CONTEXT.md`, `docs/ARCHITECTURE.md`, `agents/IMPLEMENTATION.md` | Architecture and conventions — read when present |
 | Optional user instructions | `agents/user-instructions/` | Test guidelines, custom matchers, style |
-| Optional frontend source | repo-specific (e.g. `RefSrc/<repo>/`) | Component files for selector / test-id discovery |
+| Optional frontend source | repo-specific (e.g. `refsrc/<repo>/`) | Component files for selector / test-id discovery |
 | Output | `plans/ui-aqa-<test-name>/code-analysis.md` | The report (this phase's contract, below) |
 
 **Input GATE.** Before analysis: test plan exists and is non-empty; `project_description.md`, `gain.json`, or one authoritative project-context file exists; codebase root is readable. Resolve file locations from `gain.json`, falling back to the canonical paths above. Any miss → stop Phase 3, record the gap in `ui-aqa-state.md`, ask the user. Do NOT infer framework from incidental file extensions.
@@ -57,7 +57,7 @@ After writing the report, update the test plan's `## Code Analysis` section with
 2. USE SKILL `reverse-engineering` and USE SKILL `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis) with the phase-supplied bindings: inputs + defaults = `<input_contract>`; report structure + test-location rule = the skill's code-analysis report template; output path = `plans/ui-aqa-<test-name>/code-analysis.md`. USE SKILL `sensitive-data` before writing.
 3. **Conditional-input else-paths:**
    - If `agents/user-instructions/` is **absent or empty**: record `not available — see Coverage section` in report section 2 and `not available` in section 9; Phase 3 **continues**, does not stop.
-   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `RefSrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
+   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `refsrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
 4. Do not fabricate framework, page objects, or pass/fail data. Honor the read-only scope (`<workflow_context>`).
 5. **Post-analysis verification:** confirm the report exists with every section from the code-analysis report template and the test plan's `## Code Analysis` summary is added. If missing/incomplete: re-run once with the same bindings; if still failing, stop Phase 3, record `Phase 3 blocked: code-analysis report not produced/incomplete` in `agents/TEMP/<FEATURE>/ui-aqa-state.md`, ask the user.
 </execute_analysis>

--- a/plugins/core-codex/.agents/skills/api-aqa-flow/phases/api-aqa-flow-api-spec-analysis.md
+++ b/plugins/core-codex/.agents/skills/api-aqa-flow/phases/api-aqa-flow-api-spec-analysis.md
@@ -28,7 +28,7 @@ The phase supplies the skill two required inputs; the skill GATEs on both before
 
 <determine_spec_source step="2.1">
 
-Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `RefSrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `RefSrc/{project-name}/docs/` to understand API architecture before searching source code.
+Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `refsrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `refsrc/{project-name}/docs/` to understand API architecture before searching source code.
 
 Determine spec source in order:
 

--- a/plugins/core-codex/.agents/skills/api-aqa-flow/phases/api-aqa-flow-data-collection.md
+++ b/plugins/core-codex/.agents/skills/api-aqa-flow/phases/api-aqa-flow-data-collection.md
@@ -26,7 +26,7 @@ This phase owns the raw-data aggregation artifact `plans/api-aqa-{IDENTIFIER}/ra
 - **Test Case Data** — from `data-collection` (role `TMS`, resolved provider); ≥1 test-case source required.
 - **Documentation / Wiki** — from `data-collection` (role `Wiki`, resolved provider) via step 1.2b when scoped; else the `SKIPPED_NO_CONFIG` outcome row (per `<wiki_outcomes>`).
 - **Existing Test Patterns** — from `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis, via `reverse-engineering`); framework, HTTP client, structure/assertion/auth conventions, reusable utilities. Record env-file **path + variable names only**, never literal values.
-- **Backend Source Code Analysis** — backend path from config or discoverable `RefSrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
+- **Backend Source Code Analysis** — backend path from config or discoverable `refsrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
 - **API Endpoints Identified** — every row has Method + Source populated; partial rows tagged as gaps.
 - **Data Collection Summary** — counts + gap notes; a delegated-skill stop is recorded verbatim as `Gap: <skill> stopped — <message>`, never fabricated over.
 

--- a/plugins/core-codex/.agents/skills/external-lib-flow/SKILL.md
+++ b/plugins/core-codex/.agents/skills/external-lib-flow/SKILL.md
@@ -11,14 +11,14 @@ baseSchema: docs/schemas/workflow.md
 
 - Purpose: Onboard AI to external codebase for usage understanding
 - Tool: Repomix MCP to package codebase (compressed XML)
-- Target: Two documents in RefSrc folder and in Rosetta
+- Target: Two documents in refsrc folder and in Rosetta
   1. File: `{project-name}.xml` (compressed codebase, unmodified Repomix output)
   2. File: `{project-name}-onboarding.md` (brief Learning Flow with reference)
 - Files involved: Project path, README, package files for auto-detection
 - MUST generate brief Learning Flow (3-5 words per step, max 20 lines)
 - MUST use compressed XML (Tree-sitter) for small output
 - Onboarding document MUST specify KB title and search instructions
-- Update ARCHITECTURE.md based on template `MUST use RefSrc/{project-name}.xml and RefSrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
+- Update ARCHITECTURE.md based on template `MUST use refsrc/{project-name}.xml and refsrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
 - Workflow state MUST be saved to `agents/TEMP/<FEATURE>/external-lib-flow-state.md` file.
 
 ## Onboarding Flow

--- a/plugins/core-codex/.agents/skills/qa-structure/assets/api-aqa-config-interview.md
+++ b/plugins/core-codex/.agents/skills/qa-structure/assets/api-aqa-config-interview.md
@@ -36,8 +36,8 @@ To automate backend API tests effectively, I need the following project details:
    - How should tests authenticate? (test credentials, mock auth, service account)
    - ⚠️ Do NOT paste literal credential values (tokens, passwords, API keys) — describe the **mechanism + source** only (e.g. "Bearer JWT from AuthHelper; credentials in env var `AUTH_TOKEN`").
 
-6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md RefSrc references):
-   - In RefSrc/ folder (provide project name, e.g., RefSrc/my-backend/)
+6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md refsrc references):
+   - In refsrc/ folder (provide project name, e.g., refsrc/my-backend/)
    - In the current workspace (provide path, e.g., src/, backend/)
    - Not available (I will work from Swagger/docs only)
 

--- a/plugins/core-codex/.agents/skills/qa-structure/references/config-schema.md
+++ b/plugins/core-codex/.agents/skills/qa-structure/references/config-schema.md
@@ -15,7 +15,7 @@ The project-config-loading phase completes only when every required key below ho
 | `Wiki / Document Storage` -- `wiki_base_url` | data-collection phase (scope detection + access) | Base URL or `N/A -- wiki_provider: <none/local>` |
 | `API Specification` -- `swagger_url` (or path) | api-spec-analysis phase | URL/path, or `N/A -- no Swagger spec available; code-based analysis will run` |
 | `API Specification` -- `spec_format` | api-spec-analysis phase | One of: `OpenAPI 3.x` / `Swagger 2.0` / `N/A` |
-| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `RefSrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
+| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `refsrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
 | `Test Case Management` -- `tms_provider` | data-collection phase (branch selector) | Provider name (e.g. `testrail` / `jira` / `confluence`) or `manual` / `other` |
 | `Test Case Management` -- `tms_base_url` | data-collection phase (provider access) | Base URL or `N/A -- tms_provider: manual` |
 | `Test Case Management` -- `project_id` / `suite_id` | data-collection phase (provider-specific run identifiers; TestRail project/suite is the canonical example) | IDs, or `N/A -- tms_provider: <value without project/suite IDs>` |

--- a/plugins/core-codex/.agents/skills/ui-aqa-flow/phases/ui-aqa-flow-code-analysis.md
+++ b/plugins/core-codex/.agents/skills/ui-aqa-flow/phases/ui-aqa-flow-code-analysis.md
@@ -23,7 +23,7 @@ The phase supplies these paths to the skill; defaults apply when not configured:
 | Project description | `project_description.md` (repo root) | Framework, language, structure, coding standards — read when present |
 | Project context | configured paths; canonical `docs/CONTEXT.md`, `docs/ARCHITECTURE.md`, `agents/IMPLEMENTATION.md` | Architecture and conventions — read when present |
 | Optional user instructions | `agents/user-instructions/` | Test guidelines, custom matchers, style |
-| Optional frontend source | repo-specific (e.g. `RefSrc/<repo>/`) | Component files for selector / test-id discovery |
+| Optional frontend source | repo-specific (e.g. `refsrc/<repo>/`) | Component files for selector / test-id discovery |
 | Output | `plans/ui-aqa-<test-name>/code-analysis.md` | The report (this phase's contract, below) |
 
 **Input GATE.** Before analysis: test plan exists and is non-empty; `project_description.md`, `gain.json`, or one authoritative project-context file exists; codebase root is readable. Resolve file locations from `gain.json`, falling back to the canonical paths above. Any miss → stop Phase 3, record the gap in `ui-aqa-state.md`, ask the user. Do NOT infer framework from incidental file extensions.
@@ -48,7 +48,7 @@ After writing the report, update the test plan's `## Code Analysis` section with
 2. USE SKILL `reverse-engineering` and USE SKILL `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis) with the phase-supplied bindings: inputs + defaults = `<input_contract>`; report structure + test-location rule = the skill's code-analysis report template; output path = `plans/ui-aqa-<test-name>/code-analysis.md`. USE SKILL `sensitive-data` before writing.
 3. **Conditional-input else-paths:**
    - If `agents/user-instructions/` is **absent or empty**: record `not available — see Coverage section` in report section 2 and `not available` in section 9; Phase 3 **continues**, does not stop.
-   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `RefSrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
+   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `refsrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
 4. Do not fabricate framework, page objects, or pass/fail data. Honor the read-only scope (`<workflow_context>`).
 5. **Post-analysis verification:** confirm the report exists with every section from the code-analysis report template and the test plan's `## Code Analysis` summary is added. If missing/incomplete: re-run once with the same bindings; if still failing, stop Phase 3, record `Phase 3 blocked: code-analysis report not produced/incomplete` in `agents/TEMP/<FEATURE>/ui-aqa-state.md`, ask the user.
 </execute_analysis>

--- a/plugins/core-copilot-standalone/.github/prompts/api-aqa-flow-api-spec-analysis.prompt.md
+++ b/plugins/core-copilot-standalone/.github/prompts/api-aqa-flow-api-spec-analysis.prompt.md
@@ -37,7 +37,7 @@ The phase supplies the skill two required inputs; the skill GATEs on both before
 
 <determine_spec_source step="2.1">
 
-Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `RefSrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `RefSrc/{project-name}/docs/` to understand API architecture before searching source code.
+Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `refsrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `refsrc/{project-name}/docs/` to understand API architecture before searching source code.
 
 Determine spec source in order:
 

--- a/plugins/core-copilot-standalone/.github/prompts/api-aqa-flow-data-collection.prompt.md
+++ b/plugins/core-copilot-standalone/.github/prompts/api-aqa-flow-data-collection.prompt.md
@@ -35,7 +35,7 @@ This phase owns the raw-data aggregation artifact `plans/api-aqa-{IDENTIFIER}/ra
 - **Test Case Data** — from `data-collection` (role `TMS`, resolved provider); ≥1 test-case source required.
 - **Documentation / Wiki** — from `data-collection` (role `Wiki`, resolved provider) via step 1.2b when scoped; else the `SKIPPED_NO_CONFIG` outcome row (per `<wiki_outcomes>`).
 - **Existing Test Patterns** — from `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis, via `reverse-engineering`); framework, HTTP client, structure/assertion/auth conventions, reusable utilities. Record env-file **path + variable names only**, never literal values.
-- **Backend Source Code Analysis** — backend path from config or discoverable `RefSrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
+- **Backend Source Code Analysis** — backend path from config or discoverable `refsrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
 - **API Endpoints Identified** — every row has Method + Source populated; partial rows tagged as gaps.
 - **Data Collection Summary** — counts + gap notes; a delegated-skill stop is recorded verbatim as `Gap: <skill> stopped — <message>`, never fabricated over.
 

--- a/plugins/core-copilot-standalone/.github/prompts/external-lib-flow.prompt.md
+++ b/plugins/core-copilot-standalone/.github/prompts/external-lib-flow.prompt.md
@@ -11,14 +11,14 @@ baseSchema: docs/schemas/workflow.md
 
 - Purpose: Onboard AI to external codebase for usage understanding
 - Tool: Repomix MCP to package codebase (compressed XML)
-- Target: Two documents in RefSrc folder and in Rosetta
+- Target: Two documents in refsrc folder and in Rosetta
   1. File: `{project-name}.xml` (compressed codebase, unmodified Repomix output)
   2. File: `{project-name}-onboarding.md` (brief Learning Flow with reference)
 - Files involved: Project path, README, package files for auto-detection
 - MUST generate brief Learning Flow (3-5 words per step, max 20 lines)
 - MUST use compressed XML (Tree-sitter) for small output
 - Onboarding document MUST specify KB title and search instructions
-- Update ARCHITECTURE.md based on template `MUST use RefSrc/{project-name}.xml and RefSrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
+- Update ARCHITECTURE.md based on template `MUST use refsrc/{project-name}.xml and refsrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
 - Workflow state MUST be saved to `agents/TEMP/<FEATURE>/external-lib-flow-state.md` file.
 
 ## Onboarding Flow

--- a/plugins/core-copilot-standalone/.github/prompts/ui-aqa-flow-code-analysis.prompt.md
+++ b/plugins/core-copilot-standalone/.github/prompts/ui-aqa-flow-code-analysis.prompt.md
@@ -32,7 +32,7 @@ The phase supplies these paths to the skill; defaults apply when not configured:
 | Project description | `project_description.md` (repo root) | Framework, language, structure, coding standards — read when present |
 | Project context | configured paths; canonical `docs/CONTEXT.md`, `docs/ARCHITECTURE.md`, `agents/IMPLEMENTATION.md` | Architecture and conventions — read when present |
 | Optional user instructions | `agents/user-instructions/` | Test guidelines, custom matchers, style |
-| Optional frontend source | repo-specific (e.g. `RefSrc/<repo>/`) | Component files for selector / test-id discovery |
+| Optional frontend source | repo-specific (e.g. `refsrc/<repo>/`) | Component files for selector / test-id discovery |
 | Output | `plans/ui-aqa-<test-name>/code-analysis.md` | The report (this phase's contract, below) |
 
 **Input GATE.** Before analysis: test plan exists and is non-empty; `project_description.md`, `gain.json`, or one authoritative project-context file exists; codebase root is readable. Resolve file locations from `gain.json`, falling back to the canonical paths above. Any miss → stop Phase 3, record the gap in `ui-aqa-state.md`, ask the user. Do NOT infer framework from incidental file extensions.
@@ -57,7 +57,7 @@ After writing the report, update the test plan's `## Code Analysis` section with
 2. USE SKILL `reverse-engineering` and USE SKILL `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis) with the phase-supplied bindings: inputs + defaults = `<input_contract>`; report structure + test-location rule = the skill's code-analysis report template; output path = `plans/ui-aqa-<test-name>/code-analysis.md`. USE SKILL `sensitive-data` before writing.
 3. **Conditional-input else-paths:**
    - If `agents/user-instructions/` is **absent or empty**: record `not available — see Coverage section` in report section 2 and `not available` in section 9; Phase 3 **continues**, does not stop.
-   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `RefSrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
+   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `refsrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
 4. Do not fabricate framework, page objects, or pass/fail data. Honor the read-only scope (`<workflow_context>`).
 5. **Post-analysis verification:** confirm the report exists with every section from the code-analysis report template and the test plan's `## Code Analysis` summary is added. If missing/incomplete: re-run once with the same bindings; if still failing, stop Phase 3, record `Phase 3 blocked: code-analysis report not produced/incomplete` in `agents/TEMP/<FEATURE>/ui-aqa-state.md`, ask the user.
 </execute_analysis>

--- a/plugins/core-copilot-standalone/.github/skills/qa-structure/assets/api-aqa-config-interview.md
+++ b/plugins/core-copilot-standalone/.github/skills/qa-structure/assets/api-aqa-config-interview.md
@@ -36,8 +36,8 @@ To automate backend API tests effectively, I need the following project details:
    - How should tests authenticate? (test credentials, mock auth, service account)
    - ⚠️ Do NOT paste literal credential values (tokens, passwords, API keys) — describe the **mechanism + source** only (e.g. "Bearer JWT from AuthHelper; credentials in env var `AUTH_TOKEN`").
 
-6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md RefSrc references):
-   - In RefSrc/ folder (provide project name, e.g., RefSrc/my-backend/)
+6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md refsrc references):
+   - In refsrc/ folder (provide project name, e.g., refsrc/my-backend/)
    - In the current workspace (provide path, e.g., src/, backend/)
    - Not available (I will work from Swagger/docs only)
 

--- a/plugins/core-copilot-standalone/.github/skills/qa-structure/references/config-schema.md
+++ b/plugins/core-copilot-standalone/.github/skills/qa-structure/references/config-schema.md
@@ -15,7 +15,7 @@ The project-config-loading phase completes only when every required key below ho
 | `Wiki / Document Storage` -- `wiki_base_url` | data-collection phase (scope detection + access) | Base URL or `N/A -- wiki_provider: <none/local>` |
 | `API Specification` -- `swagger_url` (or path) | api-spec-analysis phase | URL/path, or `N/A -- no Swagger spec available; code-based analysis will run` |
 | `API Specification` -- `spec_format` | api-spec-analysis phase | One of: `OpenAPI 3.x` / `Swagger 2.0` / `N/A` |
-| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `RefSrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
+| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `refsrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
 | `Test Case Management` -- `tms_provider` | data-collection phase (branch selector) | Provider name (e.g. `testrail` / `jira` / `confluence`) or `manual` / `other` |
 | `Test Case Management` -- `tms_base_url` | data-collection phase (provider access) | Base URL or `N/A -- tms_provider: manual` |
 | `Test Case Management` -- `project_id` / `suite_id` | data-collection phase (provider-specific run identifiers; TestRail project/suite is the canonical example) | IDs, or `N/A -- tms_provider: <value without project/suite IDs>` |

--- a/plugins/core-copilot/commands/api-aqa-flow-api-spec-analysis.md
+++ b/plugins/core-copilot/commands/api-aqa-flow-api-spec-analysis.md
@@ -37,7 +37,7 @@ The phase supplies the skill two required inputs; the skill GATEs on both before
 
 <determine_spec_source step="2.1">
 
-Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `RefSrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `RefSrc/{project-name}/docs/` to understand API architecture before searching source code.
+Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `refsrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `refsrc/{project-name}/docs/` to understand API architecture before searching source code.
 
 Determine spec source in order:
 

--- a/plugins/core-copilot/commands/api-aqa-flow-data-collection.md
+++ b/plugins/core-copilot/commands/api-aqa-flow-data-collection.md
@@ -35,7 +35,7 @@ This phase owns the raw-data aggregation artifact `plans/api-aqa-{IDENTIFIER}/ra
 - **Test Case Data** — from `data-collection` (role `TMS`, resolved provider); ≥1 test-case source required.
 - **Documentation / Wiki** — from `data-collection` (role `Wiki`, resolved provider) via step 1.2b when scoped; else the `SKIPPED_NO_CONFIG` outcome row (per `<wiki_outcomes>`).
 - **Existing Test Patterns** — from `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis, via `reverse-engineering`); framework, HTTP client, structure/assertion/auth conventions, reusable utilities. Record env-file **path + variable names only**, never literal values.
-- **Backend Source Code Analysis** — backend path from config or discoverable `RefSrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
+- **Backend Source Code Analysis** — backend path from config or discoverable `refsrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
 - **API Endpoints Identified** — every row has Method + Source populated; partial rows tagged as gaps.
 - **Data Collection Summary** — counts + gap notes; a delegated-skill stop is recorded verbatim as `Gap: <skill> stopped — <message>`, never fabricated over.
 

--- a/plugins/core-copilot/commands/external-lib-flow.md
+++ b/plugins/core-copilot/commands/external-lib-flow.md
@@ -11,14 +11,14 @@ baseSchema: docs/schemas/workflow.md
 
 - Purpose: Onboard AI to external codebase for usage understanding
 - Tool: Repomix MCP to package codebase (compressed XML)
-- Target: Two documents in RefSrc folder and in Rosetta
+- Target: Two documents in refsrc folder and in Rosetta
   1. File: `{project-name}.xml` (compressed codebase, unmodified Repomix output)
   2. File: `{project-name}-onboarding.md` (brief Learning Flow with reference)
 - Files involved: Project path, README, package files for auto-detection
 - MUST generate brief Learning Flow (3-5 words per step, max 20 lines)
 - MUST use compressed XML (Tree-sitter) for small output
 - Onboarding document MUST specify KB title and search instructions
-- Update ARCHITECTURE.md based on template `MUST use RefSrc/{project-name}.xml and RefSrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
+- Update ARCHITECTURE.md based on template `MUST use refsrc/{project-name}.xml and refsrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
 - Workflow state MUST be saved to `agents/TEMP/<FEATURE>/external-lib-flow-state.md` file.
 
 ## Onboarding Flow

--- a/plugins/core-copilot/commands/ui-aqa-flow-code-analysis.md
+++ b/plugins/core-copilot/commands/ui-aqa-flow-code-analysis.md
@@ -32,7 +32,7 @@ The phase supplies these paths to the skill; defaults apply when not configured:
 | Project description | `project_description.md` (repo root) | Framework, language, structure, coding standards — read when present |
 | Project context | configured paths; canonical `docs/CONTEXT.md`, `docs/ARCHITECTURE.md`, `agents/IMPLEMENTATION.md` | Architecture and conventions — read when present |
 | Optional user instructions | `agents/user-instructions/` | Test guidelines, custom matchers, style |
-| Optional frontend source | repo-specific (e.g. `RefSrc/<repo>/`) | Component files for selector / test-id discovery |
+| Optional frontend source | repo-specific (e.g. `refsrc/<repo>/`) | Component files for selector / test-id discovery |
 | Output | `plans/ui-aqa-<test-name>/code-analysis.md` | The report (this phase's contract, below) |
 
 **Input GATE.** Before analysis: test plan exists and is non-empty; `project_description.md`, `gain.json`, or one authoritative project-context file exists; codebase root is readable. Resolve file locations from `gain.json`, falling back to the canonical paths above. Any miss → stop Phase 3, record the gap in `ui-aqa-state.md`, ask the user. Do NOT infer framework from incidental file extensions.
@@ -57,7 +57,7 @@ After writing the report, update the test plan's `## Code Analysis` section with
 2. USE SKILL `reverse-engineering` and USE SKILL `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis) with the phase-supplied bindings: inputs + defaults = `<input_contract>`; report structure + test-location rule = the skill's code-analysis report template; output path = `plans/ui-aqa-<test-name>/code-analysis.md`. USE SKILL `sensitive-data` before writing.
 3. **Conditional-input else-paths:**
    - If `agents/user-instructions/` is **absent or empty**: record `not available — see Coverage section` in report section 2 and `not available` in section 9; Phase 3 **continues**, does not stop.
-   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `RefSrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
+   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `refsrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
 4. Do not fabricate framework, page objects, or pass/fail data. Honor the read-only scope (`<workflow_context>`).
 5. **Post-analysis verification:** confirm the report exists with every section from the code-analysis report template and the test plan's `## Code Analysis` summary is added. If missing/incomplete: re-run once with the same bindings; if still failing, stop Phase 3, record `Phase 3 blocked: code-analysis report not produced/incomplete` in `agents/TEMP/<FEATURE>/ui-aqa-state.md`, ask the user.
 </execute_analysis>

--- a/plugins/core-copilot/skills/qa-structure/assets/api-aqa-config-interview.md
+++ b/plugins/core-copilot/skills/qa-structure/assets/api-aqa-config-interview.md
@@ -36,8 +36,8 @@ To automate backend API tests effectively, I need the following project details:
    - How should tests authenticate? (test credentials, mock auth, service account)
    - ⚠️ Do NOT paste literal credential values (tokens, passwords, API keys) — describe the **mechanism + source** only (e.g. "Bearer JWT from AuthHelper; credentials in env var `AUTH_TOKEN`").
 
-6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md RefSrc references):
-   - In RefSrc/ folder (provide project name, e.g., RefSrc/my-backend/)
+6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md refsrc references):
+   - In refsrc/ folder (provide project name, e.g., refsrc/my-backend/)
    - In the current workspace (provide path, e.g., src/, backend/)
    - Not available (I will work from Swagger/docs only)
 

--- a/plugins/core-copilot/skills/qa-structure/references/config-schema.md
+++ b/plugins/core-copilot/skills/qa-structure/references/config-schema.md
@@ -15,7 +15,7 @@ The project-config-loading phase completes only when every required key below ho
 | `Wiki / Document Storage` -- `wiki_base_url` | data-collection phase (scope detection + access) | Base URL or `N/A -- wiki_provider: <none/local>` |
 | `API Specification` -- `swagger_url` (or path) | api-spec-analysis phase | URL/path, or `N/A -- no Swagger spec available; code-based analysis will run` |
 | `API Specification` -- `spec_format` | api-spec-analysis phase | One of: `OpenAPI 3.x` / `Swagger 2.0` / `N/A` |
-| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `RefSrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
+| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `refsrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
 | `Test Case Management` -- `tms_provider` | data-collection phase (branch selector) | Provider name (e.g. `testrail` / `jira` / `confluence`) or `manual` / `other` |
 | `Test Case Management` -- `tms_base_url` | data-collection phase (provider access) | Base URL or `N/A -- tms_provider: manual` |
 | `Test Case Management` -- `project_id` / `suite_id` | data-collection phase (provider-specific run identifiers; TestRail project/suite is the canonical example) | IDs, or `N/A -- tms_provider: <value without project/suite IDs>` |

--- a/plugins/core-cursor-standalone/.cursor/commands/api-aqa-flow-api-spec-analysis.md
+++ b/plugins/core-cursor-standalone/.cursor/commands/api-aqa-flow-api-spec-analysis.md
@@ -37,7 +37,7 @@ The phase supplies the skill two required inputs; the skill GATEs on both before
 
 <determine_spec_source step="2.1">
 
-Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `RefSrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `RefSrc/{project-name}/docs/` to understand API architecture before searching source code.
+Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `refsrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `refsrc/{project-name}/docs/` to understand API architecture before searching source code.
 
 Determine spec source in order:
 

--- a/plugins/core-cursor-standalone/.cursor/commands/api-aqa-flow-data-collection.md
+++ b/plugins/core-cursor-standalone/.cursor/commands/api-aqa-flow-data-collection.md
@@ -35,7 +35,7 @@ This phase owns the raw-data aggregation artifact `plans/api-aqa-{IDENTIFIER}/ra
 - **Test Case Data** — from `data-collection` (role `TMS`, resolved provider); ≥1 test-case source required.
 - **Documentation / Wiki** — from `data-collection` (role `Wiki`, resolved provider) via step 1.2b when scoped; else the `SKIPPED_NO_CONFIG` outcome row (per `<wiki_outcomes>`).
 - **Existing Test Patterns** — from `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis, via `reverse-engineering`); framework, HTTP client, structure/assertion/auth conventions, reusable utilities. Record env-file **path + variable names only**, never literal values.
-- **Backend Source Code Analysis** — backend path from config or discoverable `RefSrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
+- **Backend Source Code Analysis** — backend path from config or discoverable `refsrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
 - **API Endpoints Identified** — every row has Method + Source populated; partial rows tagged as gaps.
 - **Data Collection Summary** — counts + gap notes; a delegated-skill stop is recorded verbatim as `Gap: <skill> stopped — <message>`, never fabricated over.
 

--- a/plugins/core-cursor-standalone/.cursor/commands/external-lib-flow.md
+++ b/plugins/core-cursor-standalone/.cursor/commands/external-lib-flow.md
@@ -11,14 +11,14 @@ baseSchema: docs/schemas/workflow.md
 
 - Purpose: Onboard AI to external codebase for usage understanding
 - Tool: Repomix MCP to package codebase (compressed XML)
-- Target: Two documents in RefSrc folder and in Rosetta
+- Target: Two documents in refsrc folder and in Rosetta
   1. File: `{project-name}.xml` (compressed codebase, unmodified Repomix output)
   2. File: `{project-name}-onboarding.md` (brief Learning Flow with reference)
 - Files involved: Project path, README, package files for auto-detection
 - MUST generate brief Learning Flow (3-5 words per step, max 20 lines)
 - MUST use compressed XML (Tree-sitter) for small output
 - Onboarding document MUST specify KB title and search instructions
-- Update ARCHITECTURE.md based on template `MUST use RefSrc/{project-name}.xml and RefSrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
+- Update ARCHITECTURE.md based on template `MUST use refsrc/{project-name}.xml and refsrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
 - Workflow state MUST be saved to `agents/TEMP/<FEATURE>/external-lib-flow-state.md` file.
 
 ## Onboarding Flow

--- a/plugins/core-cursor-standalone/.cursor/commands/ui-aqa-flow-code-analysis.md
+++ b/plugins/core-cursor-standalone/.cursor/commands/ui-aqa-flow-code-analysis.md
@@ -32,7 +32,7 @@ The phase supplies these paths to the skill; defaults apply when not configured:
 | Project description | `project_description.md` (repo root) | Framework, language, structure, coding standards — read when present |
 | Project context | configured paths; canonical `docs/CONTEXT.md`, `docs/ARCHITECTURE.md`, `agents/IMPLEMENTATION.md` | Architecture and conventions — read when present |
 | Optional user instructions | `agents/user-instructions/` | Test guidelines, custom matchers, style |
-| Optional frontend source | repo-specific (e.g. `RefSrc/<repo>/`) | Component files for selector / test-id discovery |
+| Optional frontend source | repo-specific (e.g. `refsrc/<repo>/`) | Component files for selector / test-id discovery |
 | Output | `plans/ui-aqa-<test-name>/code-analysis.md` | The report (this phase's contract, below) |
 
 **Input GATE.** Before analysis: test plan exists and is non-empty; `project_description.md`, `gain.json`, or one authoritative project-context file exists; codebase root is readable. Resolve file locations from `gain.json`, falling back to the canonical paths above. Any miss → stop Phase 3, record the gap in `ui-aqa-state.md`, ask the user. Do NOT infer framework from incidental file extensions.
@@ -57,7 +57,7 @@ After writing the report, update the test plan's `## Code Analysis` section with
 2. USE SKILL `reverse-engineering` and USE SKILL `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis) with the phase-supplied bindings: inputs + defaults = `<input_contract>`; report structure + test-location rule = the skill's code-analysis report template; output path = `plans/ui-aqa-<test-name>/code-analysis.md`. USE SKILL `sensitive-data` before writing.
 3. **Conditional-input else-paths:**
    - If `agents/user-instructions/` is **absent or empty**: record `not available — see Coverage section` in report section 2 and `not available` in section 9; Phase 3 **continues**, does not stop.
-   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `RefSrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
+   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `refsrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
 4. Do not fabricate framework, page objects, or pass/fail data. Honor the read-only scope (`<workflow_context>`).
 5. **Post-analysis verification:** confirm the report exists with every section from the code-analysis report template and the test plan's `## Code Analysis` summary is added. If missing/incomplete: re-run once with the same bindings; if still failing, stop Phase 3, record `Phase 3 blocked: code-analysis report not produced/incomplete` in `agents/TEMP/<FEATURE>/ui-aqa-state.md`, ask the user.
 </execute_analysis>

--- a/plugins/core-cursor-standalone/.cursor/skills/qa-structure/assets/api-aqa-config-interview.md
+++ b/plugins/core-cursor-standalone/.cursor/skills/qa-structure/assets/api-aqa-config-interview.md
@@ -36,8 +36,8 @@ To automate backend API tests effectively, I need the following project details:
    - How should tests authenticate? (test credentials, mock auth, service account)
    - ⚠️ Do NOT paste literal credential values (tokens, passwords, API keys) — describe the **mechanism + source** only (e.g. "Bearer JWT from AuthHelper; credentials in env var `AUTH_TOKEN`").
 
-6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md RefSrc references):
-   - In RefSrc/ folder (provide project name, e.g., RefSrc/my-backend/)
+6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md refsrc references):
+   - In refsrc/ folder (provide project name, e.g., refsrc/my-backend/)
    - In the current workspace (provide path, e.g., src/, backend/)
    - Not available (I will work from Swagger/docs only)
 

--- a/plugins/core-cursor-standalone/.cursor/skills/qa-structure/references/config-schema.md
+++ b/plugins/core-cursor-standalone/.cursor/skills/qa-structure/references/config-schema.md
@@ -15,7 +15,7 @@ The project-config-loading phase completes only when every required key below ho
 | `Wiki / Document Storage` -- `wiki_base_url` | data-collection phase (scope detection + access) | Base URL or `N/A -- wiki_provider: <none/local>` |
 | `API Specification` -- `swagger_url` (or path) | api-spec-analysis phase | URL/path, or `N/A -- no Swagger spec available; code-based analysis will run` |
 | `API Specification` -- `spec_format` | api-spec-analysis phase | One of: `OpenAPI 3.x` / `Swagger 2.0` / `N/A` |
-| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `RefSrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
+| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `refsrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
 | `Test Case Management` -- `tms_provider` | data-collection phase (branch selector) | Provider name (e.g. `testrail` / `jira` / `confluence`) or `manual` / `other` |
 | `Test Case Management` -- `tms_base_url` | data-collection phase (provider access) | Base URL or `N/A -- tms_provider: manual` |
 | `Test Case Management` -- `project_id` / `suite_id` | data-collection phase (provider-specific run identifiers; TestRail project/suite is the canonical example) | IDs, or `N/A -- tms_provider: <value without project/suite IDs>` |

--- a/plugins/core-cursor/commands/api-aqa-flow-api-spec-analysis.md
+++ b/plugins/core-cursor/commands/api-aqa-flow-api-spec-analysis.md
@@ -37,7 +37,7 @@ The phase supplies the skill two required inputs; the skill GATEs on both before
 
 <determine_spec_source step="2.1">
 
-Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `RefSrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `RefSrc/{project-name}/docs/` to understand API architecture before searching source code.
+Determine `{backend-source-path}` from Phase 1 raw data "Backend Source Code Analysis" section, or from project config "Backend Source Code" section, or from Rosetta docs at `refsrc/{project-name}/docs/` (the backend-source scan lives in the data-collection phase's **Backend Source Code Analysis** section). If Rosetta docs exist for the backend project, read `ARCHITECTURE.md` and `CODEMAP.md` from `refsrc/{project-name}/docs/` to understand API architecture before searching source code.
 
 Determine spec source in order:
 

--- a/plugins/core-cursor/commands/api-aqa-flow-data-collection.md
+++ b/plugins/core-cursor/commands/api-aqa-flow-data-collection.md
@@ -35,7 +35,7 @@ This phase owns the raw-data aggregation artifact `plans/api-aqa-{IDENTIFIER}/ra
 - **Test Case Data** — from `data-collection` (role `TMS`, resolved provider); ≥1 test-case source required.
 - **Documentation / Wiki** — from `data-collection` (role `Wiki`, resolved provider) via step 1.2b when scoped; else the `SKIPPED_NO_CONFIG` outcome row (per `<wiki_outcomes>`).
 - **Existing Test Patterns** — from `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis, via `reverse-engineering`); framework, HTTP client, structure/assertion/auth conventions, reusable utilities. Record env-file **path + variable names only**, never literal values.
-- **Backend Source Code Analysis** — backend path from config or discoverable `RefSrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
+- **Backend Source Code Analysis** — backend path from config or discoverable `refsrc/` docs; framework, route patterns, key dirs (or `N/A` when no path).
 - **API Endpoints Identified** — every row has Method + Source populated; partial rows tagged as gaps.
 - **Data Collection Summary** — counts + gap notes; a delegated-skill stop is recorded verbatim as `Gap: <skill> stopped — <message>`, never fabricated over.
 

--- a/plugins/core-cursor/commands/external-lib-flow.md
+++ b/plugins/core-cursor/commands/external-lib-flow.md
@@ -11,14 +11,14 @@ baseSchema: docs/schemas/workflow.md
 
 - Purpose: Onboard AI to external codebase for usage understanding
 - Tool: Repomix MCP to package codebase (compressed XML)
-- Target: Two documents in RefSrc folder and in Rosetta
+- Target: Two documents in refsrc folder and in Rosetta
   1. File: `{project-name}.xml` (compressed codebase, unmodified Repomix output)
   2. File: `{project-name}-onboarding.md` (brief Learning Flow with reference)
 - Files involved: Project path, README, package files for auto-detection
 - MUST generate brief Learning Flow (3-5 words per step, max 20 lines)
 - MUST use compressed XML (Tree-sitter) for small output
 - Onboarding document MUST specify KB title and search instructions
-- Update ARCHITECTURE.md based on template `MUST use RefSrc/{project-name}.xml and RefSrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
+- Update ARCHITECTURE.md based on template `MUST use refsrc/{project-name}.xml and refsrc/{project-name}-onboarding.md. MUST use grep or search with those, because those are big files.`. Combine this rule for multiple external dependencies.
 - Workflow state MUST be saved to `agents/TEMP/<FEATURE>/external-lib-flow-state.md` file.
 
 ## Onboarding Flow

--- a/plugins/core-cursor/commands/ui-aqa-flow-code-analysis.md
+++ b/plugins/core-cursor/commands/ui-aqa-flow-code-analysis.md
@@ -32,7 +32,7 @@ The phase supplies these paths to the skill; defaults apply when not configured:
 | Project description | `project_description.md` (repo root) | Framework, language, structure, coding standards — read when present |
 | Project context | configured paths; canonical `docs/CONTEXT.md`, `docs/ARCHITECTURE.md`, `agents/IMPLEMENTATION.md` | Architecture and conventions — read when present |
 | Optional user instructions | `agents/user-instructions/` | Test guidelines, custom matchers, style |
-| Optional frontend source | repo-specific (e.g. `RefSrc/<repo>/`) | Component files for selector / test-id discovery |
+| Optional frontend source | repo-specific (e.g. `refsrc/<repo>/`) | Component files for selector / test-id discovery |
 | Output | `plans/ui-aqa-<test-name>/code-analysis.md` | The report (this phase's contract, below) |
 
 **Input GATE.** Before analysis: test plan exists and is non-empty; `project_description.md`, `gain.json`, or one authoritative project-context file exists; codebase root is readable. Resolve file locations from `gain.json`, falling back to the canonical paths above. Any miss → stop Phase 3, record the gap in `ui-aqa-state.md`, ask the user. Do NOT infer framework from incidental file extensions.
@@ -57,7 +57,7 @@ After writing the report, update the test plan's `## Code Analysis` section with
 2. USE SKILL `reverse-engineering` and USE SKILL `qa-knowledge` (`code_analysis` mode — test-automation architecture analysis) with the phase-supplied bindings: inputs + defaults = `<input_contract>`; report structure + test-location rule = the skill's code-analysis report template; output path = `plans/ui-aqa-<test-name>/code-analysis.md`. USE SKILL `sensitive-data` before writing.
 3. **Conditional-input else-paths:**
    - If `agents/user-instructions/` is **absent or empty**: record `not available — see Coverage section` in report section 2 and `not available` in section 9; Phase 3 **continues**, does not stop.
-   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `RefSrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
+   - If a **frontend source path is not discoverable** (no `gain.json`/configured source reference, no `refsrc/<repo>/`): skip frontend analysis, record the gap in section 9 per the coverage epistemic-honesty rule; Phase 3 **continues**.
 4. Do not fabricate framework, page objects, or pass/fail data. Honor the read-only scope (`<workflow_context>`).
 5. **Post-analysis verification:** confirm the report exists with every section from the code-analysis report template and the test plan's `## Code Analysis` summary is added. If missing/incomplete: re-run once with the same bindings; if still failing, stop Phase 3, record `Phase 3 blocked: code-analysis report not produced/incomplete` in `agents/TEMP/<FEATURE>/ui-aqa-state.md`, ask the user.
 </execute_analysis>

--- a/plugins/core-cursor/skills/qa-structure/assets/api-aqa-config-interview.md
+++ b/plugins/core-cursor/skills/qa-structure/assets/api-aqa-config-interview.md
@@ -36,8 +36,8 @@ To automate backend API tests effectively, I need the following project details:
    - How should tests authenticate? (test credentials, mock auth, service account)
    - ⚠️ Do NOT paste literal credential values (tokens, passwords, API keys) — describe the **mechanism + source** only (e.g. "Bearer JWT from AuthHelper; credentials in env var `AUTH_TOKEN`").
 
-6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md RefSrc references):
-   - In RefSrc/ folder (provide project name, e.g., RefSrc/my-backend/)
+6. **Backend Source Code** (optional — helps me analyze API routes and validation; I can also discover from ARCHITECTURE.md refsrc references):
+   - In refsrc/ folder (provide project name, e.g., refsrc/my-backend/)
    - In the current workspace (provide path, e.g., src/, backend/)
    - Not available (I will work from Swagger/docs only)
 

--- a/plugins/core-cursor/skills/qa-structure/references/config-schema.md
+++ b/plugins/core-cursor/skills/qa-structure/references/config-schema.md
@@ -15,7 +15,7 @@ The project-config-loading phase completes only when every required key below ho
 | `Wiki / Document Storage` -- `wiki_base_url` | data-collection phase (scope detection + access) | Base URL or `N/A -- wiki_provider: <none/local>` |
 | `API Specification` -- `swagger_url` (or path) | api-spec-analysis phase | URL/path, or `N/A -- no Swagger spec available; code-based analysis will run` |
 | `API Specification` -- `spec_format` | api-spec-analysis phase | One of: `OpenAPI 3.x` / `Swagger 2.0` / `N/A` |
-| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `RefSrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
+| `Backend Source Code` -- `backend_source_path` | data-collection phase, api-spec-analysis phase | Path (e.g. `refsrc/my-backend/` or `src/`) or `N/A -- work from Swagger/docs only` |
 | `Test Case Management` -- `tms_provider` | data-collection phase (branch selector) | Provider name (e.g. `testrail` / `jira` / `confluence`) or `manual` / `other` |
 | `Test Case Management` -- `tms_base_url` | data-collection phase (provider access) | Base URL or `N/A -- tms_provider: manual` |
 | `Test Case Management` -- `project_id` / `suite_id` | data-collection phase (provider-specific run identifiers; TestRail project/suite is the canonical example) | IDs, or `N/A -- tms_provider: <value without project/suite IDs>` |


### PR DESCRIPTION
Closes #179

## Summary
- Replaced every occurrence of `RefSrc/` (and bare `RefSrc`) with the canonical lowercase `refsrc/` across active (r3) and backported (r2) instruction sources, plus user-facing docs.
- Regenerated `plugins/**` via `npx -y rosettify-plugins@latest --release r3 --deterministic-hooks false` so all generated targets (core-claude, core-cursor, core-copilot, core-codex, core-cursor-standalone, core-copilot-standalone, core-antigravity) reflect the fix.
- Pure literal-string casing fix — no wording/logic changes.

**Files changed (source):**
- `instructions/r3/core/workflows/{external-lib-flow,api-aqa-flow-api-spec-analysis,api-aqa-flow-data-collection,ui-aqa-flow-code-analysis}.md`
- `instructions/r3/core/skills/qa-structure/{assets/api-aqa-config-interview.md,references/config-schema.md}`
- `instructions/r2/core/workflows/{external-lib-flow,aqa-flow-code-analysis}.md` (backport, same bug)
- `docs/web/docs/{configuration,api-aqa-flow}.md`
- `docs/manual-tests/api-aqa-flow.md`
- `plugins/**` — regenerated, not hand-edited (42 files)

## Testing notes
- `grep -rn "RefSrc" instructions/ docs/ plugins/` returns zero matches (case-sensitive).
- Regenerated plugins via the generator and confirmed the run is idempotent — re-running produces no further diff.
- `git diff --stat -- src/` is empty — no application code touched.
- Diff inspected line-by-line: every added/removed line contains only the `RefSrc` → `refsrc` swap, no unrelated content changed.
- Independent reviewer and validator subagent passes both returned PASS with no issues.

## Assumptions
- Followed the issue's approved plan verbatim, including the r2 backport (bug fix, consistent with r2's backport-only policy).