### PR TITLE
#201 Create ISSUE_TEMPLATE for the repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_prompt_issue.md
+++ b/.github/ISSUE_TEMPLATE/agent_prompt_issue.md
@@ -2,7 +2,7 @@
 name: Agent / prompt behavior issue
 about: Report an AI coding agent behaving unexpectedly while using Rosetta instructions (skills, workflows, agents, rules)
 title: "[Agent]: "
-labels: documentation
+labels: instructions
 ---
 
 ## What Happened

--- a/.github/ISSUE_TEMPLATE/agent_prompt_issue.md
+++ b/.github/ISSUE_TEMPLATE/agent_prompt_issue.md
@@ -1,0 +1,23 @@
+---
+name: Agent / prompt behavior issue
+about: Report an AI coding agent behaving unexpectedly while using Rosetta instructions (skills, workflows, agents, rules)
+title: "[Agent]: "
+labels: documentation
+---
+
+## What Happened
+
+<!-- Which skill/workflow/agent/rule was involved, and the affected path under instructions/r3/. -->
+
+## Expected Behavior
+
+<!-- What the agent should have done instead. -->
+
+## Actual Output / Transcript
+
+<!-- Paste the relevant transcript excerpt. Sanitize secrets/sensitive data before pasting.
+If you already drafted this issue via the `post-mortem` skill, link that output here instead. -->
+
+## Additional Context
+
+<!-- Anything else that helps diagnose the behavior. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a defect in Rosetta code (rosettify, rosetta-mcp-server, rosetta-cli, hooks, helm-charts, website)
+title: "[Bug]: "
+labels: bug
+---
+
+## Description
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen. -->
+
+## Actual Behavior
+
+<!-- What actually happened. -->
+
+## Environment
+
+- Component (e.g. rosettify, rosetta-mcp-server, rosetta-cli, hooks, helm-charts, website):
+- Version / commit:
+
+## Additional Context
+
+<!-- Logs, screenshots, or any other context. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Not sure where your idea fits?
+    url: https://github.com/griddynamics/rosetta/blob/main/CONTRIBUTING.md
+    about: Read CONTRIBUTING.md for guidance, or open a blank issue.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,18 @@
+---
+name: Documentation
+about: Report missing, unclear, or incorrect documentation
+title: "[Docs]: "
+labels: documentation
+---
+
+## Location
+
+<!-- File or link to the affected documentation. -->
+
+## What's Wrong or Missing
+
+<!-- Describe the issue with the current documentation. -->
+
+## Suggested Change
+
+<!-- What should it say instead? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Propose a new capability or improvement
+title: "[Feature]: "
+labels: enhancement
+---
+
+## Problem / Motivation
+
+<!-- What problem does this solve, or what's the motivation? -->
+
+## Proposed Solution
+
+<!-- Describe the solution you'd like. -->
+
+## Alternatives Considered
+
+<!-- Any alternative solutions or features you've considered. -->
+
+## Additional Context
+
+<!-- Anything else that helps evaluate this request. -->


### PR DESCRIPTION
Closes #201

## Summary
- Add `.github/ISSUE_TEMPLATE/bug_report.md` — for defects in `src/*` components (rosettify, rosetta-mcp-server, rosetta-cli, hooks, helm-charts, website)
- Add `.github/ISSUE_TEMPLATE/agent_prompt_issue.md` — for AI agent/skill/workflow misbehavior under `instructions/r3/*`, distinct from a code bug
- Add `.github/ISSUE_TEMPLATE/feature_request.md` — for new capability/improvement proposals
- Add `.github/ISSUE_TEMPLATE/documentation.md` — for missing/unclear/incorrect documentation reports
- Add `.github/ISSUE_TEMPLATE/config.yml` — keeps blank issues enabled and links to `CONTRIBUTING.md`

All templates use classic Markdown + YAML front-matter (not YAML issue-forms), matching the repo's low-friction philosophy. Front-matter `labels:` are hints only — the existing `repo-triage` automation classifies/labels issues on open.

## Assumptions
- No `instructions` label exists in the repo (checked via `gh label list`), so `agent_prompt_issue.md` reuses the existing `documentation` label per the plan's fallback option, rather than creating a new label.
- No changes made outside `.github/ISSUE_TEMPLATE/` — this is a pure-addition, no code/CI changes.

## Testing
- Static template files; no automated tests apply.
- Validated all 4 `.md` files' YAML front-matter parses correctly (`name`, `about`, `title`, `labels`) via a local YAML parse check.
- Validated `config.yml` parses and contains `blank_issues_enabled: true` plus the `CONTRIBUTING.md` contact link.
- Label names used (`bug`, `documentation`, `enhancement`) confirmed to exist in the repo via `gh label list`.