### PR TITLE
fix: tally parse status counts in parse command

### DIFF
--- a/src/rosetta-cli/rosetta_cli/commands/parse_command.py
+++ b/src/rosetta-cli/rosetta_cli/commands/parse_command.py
@@ -115,6 +115,7 @@ class ParseCommand(BaseCommand):
             print(f"Found {len(documents)} document(s) (force mode - parsing all)\n")
             
             for document in documents:
+                status = self._count_parse_status(status_counts, document)
                 doc_id = getattr(document, 'id', None)
                 if doc_id:
                     docs_to_parse.append({
@@ -122,7 +123,7 @@ class ParseCommand(BaseCommand):
                         "name": getattr(document, 'name', 'Untitled'),
                         "dataset_id": dataset.id,
                         "folder": ".",
-                        "status": getattr(document, 'run', 'UNSTART')
+                        "status": status
                     })
         else:
             # Default mode: filter by status (need parsing)
@@ -131,10 +132,17 @@ class ParseCommand(BaseCommand):
                 statuses=["FAIL", "UNSTART", "CANCEL"],
                 limit=self.config.page_size
             )
+
+            # Tally skipped documents from the full list so the summary reflects
+            # what this run will not re-trigger.
+            all_documents = dataset.list_documents(page_size=self.config.page_size)
+            for document in all_documents:
+                self._count_parse_status(status_counts, document)
             
             print(f"Found {len(documents_needing_parse)} document(s) needing parsing\n")
             
             for document in documents_needing_parse:
+                status = self._count_parse_status(status_counts, document)
                 doc_id = getattr(document, 'id', None)
                 if doc_id:
                     docs_to_parse.append({
@@ -142,10 +150,19 @@ class ParseCommand(BaseCommand):
                         "name": getattr(document, 'name', 'Untitled'),
                         "dataset_id": dataset.id,
                         "folder": ".",
-                        "status": getattr(document, 'run', 'UNSTART')
+                        "status": status
                     })
         
         return docs_to_parse, status_counts
+
+    def _count_parse_status(self, status_counts: dict[str, int], document: object) -> str:
+        """Tally a document's parse status and return it."""
+        status = getattr(document, 'run', 'UNSTART')
+        if status == 'DONE':
+            status_counts['done'] += 1
+        elif status == 'RUNNING':
+            status_counts['running'] += 1
+        return status
     
     def _print_parse_status(self, docs_to_parse: list[JsonDict], status_counts: dict[str, int], args: CommandArgs) -> None:
         """Print parsing status."""

--- a/src/rosetta-cli/tests/test_parse_command_status_counts.py
+++ b/src/rosetta-cli/tests/test_parse_command_status_counts.py
@@ -1,0 +1,79 @@
+from argparse import Namespace
+from types import SimpleNamespace
+
+from rosetta_cli.commands.parse_command import ParseCommand
+
+
+class FakeDocument:
+    def __init__(self, doc_id: str, run: str) -> None:
+        self.id = doc_id
+        self.name = doc_id
+        self.run = run
+
+
+class FakeDataset:
+    id = "dataset-1"
+
+    def __init__(self, documents: list[FakeDocument]) -> None:
+        self.documents = documents
+
+    def list_documents(self, page_size: int):
+        return self.documents
+
+
+class FakeDocumentService:
+    def __init__(self, client: object) -> None:
+        self.client = client
+
+    def list_documents_by_status(self, dataset: FakeDataset, statuses: list[str], limit: int):
+        return [
+            document for document in dataset.documents
+            if document.run in statuses
+        ]
+
+
+def _command(monkeypatch, documents: list[FakeDocument]) -> tuple[ParseCommand, FakeDataset]:
+    monkeypatch.setattr(
+        "rosetta_cli.commands.parse_command.DocumentService",
+        FakeDocumentService,
+    )
+    dataset = FakeDataset(documents)
+    command = ParseCommand(
+        SimpleNamespace(),
+        SimpleNamespace(page_size=100),
+    )
+    return command, dataset
+
+
+def test_force_mode_tallies_done_and_running(monkeypatch) -> None:
+    documents = [
+        FakeDocument("done-1", "DONE"),
+        FakeDocument("running-1", "RUNNING"),
+        FakeDocument("unstart-1", "UNSTART"),
+    ]
+    command, dataset = _command(monkeypatch, documents)
+
+    docs_to_parse, status_counts = command._get_documents_to_parse(
+        dataset,
+        Namespace(force=True),
+    )
+
+    assert len(docs_to_parse) == 3
+    assert status_counts == {"done": 1, "running": 1}
+
+
+def test_default_mode_tallies_skipped_documents(monkeypatch) -> None:
+    documents = [
+        FakeDocument("done-1", "DONE"),
+        FakeDocument("running-1", "RUNNING"),
+        FakeDocument("fail-1", "FAIL"),
+    ]
+    command, dataset = _command(monkeypatch, documents)
+
+    docs_to_parse, status_counts = command._get_documents_to_parse(
+        dataset,
+        Namespace(force=False),
+    )
+
+    assert [document["id"] for document in docs_to_parse] == ["fail-1"]
+    assert status_counts == {"done": 1, "running": 1}


### PR DESCRIPTION
Closes #205

## Summary

`rosetta-cli parse` now tallies document parse statuses instead of always printing zero skipped counts.

- In force mode, every listed document is counted by its `run` status while the parse list is built.
- In default mode, the full document list is counted so `done` and `running` documents are reported as skipped.
- Added a small `_count_parse_status` helper used by both paths.

## Tests

Added `tests/test_parse_command_status_counts.py` covering:

- force mode tallies `DONE` and `RUNNING` documents;
- default mode filters documents needing parsing while still reporting skipped statuses.

## Verification

```bash
cd src/rosetta-cli
PYTHONPATH=. uv run pytest -q
```

All 37 tests pass.

Signed off with DCO.
