### PR TITLE
chore: align workflow action versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/validate-prompts.yml
+++ b/.github/workflows/validate-prompts.yml
@@ -307,7 +307,7 @@ jobs:
 
       - name: Upload prompt validation artifacts
         if: always() && steps.changed-files.outputs.count > 0
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prompt-validation-report
           retention-days: 5


### PR DESCRIPTION
Closes #211

## Summary

Aligns the two workflow action holdouts with the rest of the repository:

- `codeql.yml`: `actions/checkout@v4` -> `actions/checkout@v5`
- `validate-prompts.yml`: `actions/upload-artifact@v4` -> `actions/upload-artifact@v6`

## Verification

- Both workflow files parse as valid YAML.
- No remaining `checkout@v4` or `upload-artifact@v4` call sites in `.github/workflows/`.

Workflow-only change.

Signed off with DCO.
