### PR TITLE
fix: pass configured timeout to team API

### DIFF
--- a/src/rosetta-mcp-server/rosetta_mcp/services/_ragflow_team_api.py
+++ b/src/rosetta-mcp-server/rosetta_mcp/services/_ragflow_team_api.py
@@ -54,6 +54,7 @@ class RAGFlowTeamAPI:
         return cls(
             base_url=_normalize_base_url(config.server_url),
             authorization=_extract_authorization(config),
+            timeout=config.ragflow_http_timeout,
         )
 
     def _request(

--- a/src/rosetta-mcp-server/tests/test_ragflow_team_api.py
+++ b/src/rosetta-mcp-server/tests/test_ragflow_team_api.py
@@ -1,0 +1,15 @@
+from types import SimpleNamespace
+
+from rosetta_mcp.services._ragflow_team_api import RAGFlowTeamAPI
+
+
+def test_from_config_uses_configured_timeout() -> None:
+    config = SimpleNamespace(
+        server_url="https://ragflow.example.invalid/",
+        api_key="test-key",
+        ragflow_http_timeout=123,
+    )
+
+    api = RAGFlowTeamAPI.from_config(config)
+
+    assert api._timeout == 123


### PR DESCRIPTION
Closes #208

## Summary

`RAGFlowTeamAPI.from_config` now passes `config.ragflow_http_timeout` into the client, so team-membership requests use the same env-configurable timeout as the rest of the HTTP clients instead of the hardcoded 30-second default.

## Tests

Added `tests/test_ragflow_team_api.py` asserting that `from_config` carries the configured timeout into the constructed client.

## Verification

```bash
cd src/rosetta-mcp-server
PYTHONPATH=. .venv/bin/python -m pytest tests/test_ragflow_team_api.py -q
```

Passes.

Signed off with DCO.
