### PR TITLE
Fix mismatched codegraph check mode tag

### DIFF
--- a/plugins/core-antigravity/skills/init-workspace-flow/phases/init-workspace-flow-codegraph.md
+++ b/plugins/core-antigravity/skills/init-workspace-flow/phases/init-workspace-flow-codegraph.md
@@ -18,7 +18,7 @@ Suggests user to install LSPs xor Code graphs only.
 4. Update state with phase status
 </phase_steps>
 
-<check_state step="6.1">
+<check_mode step="6.1">
 
 1. Read `agents/init-workspace-flow-state.md`
 2. Check if LSPs or GitNexus or Graphify is already installed 


### PR DESCRIPTION
## Summary

- rename the opening `check_state` tag to `check_mode`
- match the closing tag and sibling phase convention

## Validation

- verified all top-level instruction tags in the file are balanced and correctly nested
- `git diff --check`

Closes #234