### PR TITLE
docs: fix mismatched check_mode/check_state XML tag

### DIFF
--- a/instructions/r3/core/workflows/init-workspace-flow-codegraph.md
+++ b/instructions/r3/core/workflows/init-workspace-flow-codegraph.md
@@ -27,7 +27,7 @@ Suggests user to install LSPs xor Code graphs only.
 4. Update state with phase status
 </phase_steps>
 
-<check_state step="6.1">
+<check_mode step="6.1">
 
 1. Read `agents/init-workspace-flow-state.md`
 2. Check if LSPs or GitNexus or Graphify is already installed 


### PR DESCRIPTION
## Summary
`init-workspace-flow-codegraph.md` opens the block with `<check_state step="6.1">` but closes it with `</check_mode>`, a tag-name mismatch. Sibling phase files (`init-workspace-flow-discovery.md`, `init-workspace-flow-shells.md`) consistently use `<check_mode step="X.1">...</check_mode>`, confirming `check_mode` is the intended tag and `check_state` was a copy-paste error.

## Fix
Renamed the opening tag to `<check_mode step="6.1">` to match its closing tag and sibling files.

Fixes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)