### PR TITLE
ci: unblock fork-PR pipelines after the actions/checkout guardrail landed

### DIFF
--- a/.github/scripts/check_trace.py
+++ b/.github/scripts/check_trace.py
@@ -49,7 +49,15 @@ def blocks(msg):
 
 
 def main(path, require_mutation=True):
-    with open(path) as fh:
+    # No trace means the agent step never produced one -- it was skipped or the
+    # job failed earlier. Still a failure, but report it as one line: a traceback
+    # here reads like a fault in the guard and hides the real error further up.
+    try:
+        fh = open(path)
+    except FileNotFoundError:
+        print("::error::trace file missing at %s -- the Claude step did not run" % path)
+        return 1
+    with fh:
         msgs = json.load(fh)
     if not isinstance(msgs, list):
         msgs = [msgs]

--- a/.github/workflows/repo-triage.yml
+++ b/.github/workflows/repo-triage.yml
@@ -48,6 +48,12 @@ jobs:
         with:
           ref: main
 
+      # Fork content lands in pr/ as data the agent READS -- nothing here builds,
+      # installs or executes from that tree, and the allowlist below grants only
+      # Read plus read-only git subcommands over it. That is why opting out of the
+      # checkout guardrail is safe; persist-credentials must stay off so the base
+      # repo's GITHUB_TOKEN is never written into pr/.git/config where the agent,
+      # if a fork's content ever prompt-injects it, could read it back out.
       - name: Checkout PR content
         if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v5
@@ -55,6 +61,8 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/validate-prompts.yml
+++ b/.github/workflows/validate-prompts.yml
@@ -49,6 +49,13 @@ jobs:
           ref: main
           fetch-depth: 0 # Fetch all history to compare with base branch
 
+      # Fork content lands in pr/ as data the auditor READS -- nothing here builds,
+      # installs or executes from that tree, and the allowlist below grants only
+      # Read(pr/**) plus read-only git subcommands over it. That is why opting out
+      # of the checkout guardrail is safe; persist-credentials must stay off so the
+      # base repo's GITHUB_TOKEN is never written into pr/.git/config, which
+      # Read(pr/**) would otherwise expose. The base fetch below re-adds its own
+      # unauthenticated remote, so nothing depends on the persisted credential.
       - name: Checkout PR content
         if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v5
@@ -57,6 +64,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Install Claude Code CLI
         run: |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -374,7 +374,7 @@ Cursor and Copilot are the only plugins that need two distinct templates because
 ## Pipelines
 
 We use `.github/workflows` pipelines to build and release: MCP PyPi package, Docker Image, Publish Instructions, Publish website.
-Triggers on push to `main` or manual dispatch.
+Triggers on push to `main` or manual dispatch. Use actionlint.
 
 Website: builds the Jekyll website from `docs/web/`, deploys to GitHub Pages.
 


### PR DESCRIPTION
## Cause

On 2026-07-20 `actions/checkout` backported the `allow-unsafe-pr-checkout` guardrail to every major tag — v5.1.0 marks it `[BREAKING]` ([changelog](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/)). Both `pull_request_target` workflows check the fork's head into `pr/` and both pin the floating `@v5`, so the tag moved under them and the next fork PR — #237 — died at that step:

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow.
```

Neither agent ever ran. In `triage` the failure then surfaced as a `FileNotFoundError` traceback from `check_trace.py`, because no execution trace existed — that traceback is what shows up first in the log and misdirects away from the real cause.

## Fix

**`allow-unsafe-pr-checkout: true`** on the `Checkout PR content` step in both workflows. The guardrail exists to stop fork code being *executed* with the base repo's credentials, and neither pipeline does that: `pr/` is read, never built, installed from or run, and the agent allowlists grant only `Read` plus read-only git subcommands over that tree. The rationale is recorded in a comment on the step so it doesn't have to be re-derived.

**`persist-credentials: false`** on the same step — a separate finding, worth fixing regardless. It was writing the base repo's `GITHUB_TOKEN` into `pr/.git/config`, which validate-prompts hands to the auditor via `Read(pr/**)` and triage via unrestricted `Read`, reachable by a fork that prompt-injects the agent. Triage's token carries `issues: write` + `pull-requests: write`. Nothing depended on it: validate-prompts re-adds its own unauthenticated remote for the base fetch (public repo), and triage's `git -C pr` reads are local.

**`check_trace.py`** now reports a missing trace as one `::error::` line instead of a traceback. It still fails the job.

### Alternatives considered

- Fetching `refs/pull/N/head` from the base repo sidesteps the guardrail without a flag, but pulls byte-identical untrusted content — it only hides the opt-in from anyone auditing the workflow.
- Splitting into an untrusted producer job + trusted consumer job is the textbook pattern and becomes correct the moment these jobs start *executing* fork code. Disproportionate for a read-only pipeline today.

## Verification

- `actionlint` on both files matches the pre-edit baseline (same 16 pre-existing shellcheck infos, line numbers shifted by the added comments).
- `check_trace.py` exercised on all five paths: valid trace ± `--allow-no-op`, no-op trace ± `--allow-no-op`, and the new missing-file case. No regression from the `with` restructure.

> [!NOTE]
> `actionlint` flags `allow-unsafe-pr-checkout` as an unknown input. Its bundled checkout metadata is stale — the input is present in `action.yml` at the `v5` tag. Please don't "fix" it back.

## After merge

`pull_request_target` runs the workflow definition from the **base** branch, so #237 stays red until this lands. Then: `validate` retriggers on `synchronize`/`reopened`; `triage` doesn't listen on `synchronize`, so reopen the PR or re-run the job from the Actions UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
