### PR TITLE
#231: Add concurrency guard to publish workflow

### DIFF
--- a/.github/workflows/publish-instructions.yml
+++ b/.github/workflows/publish-instructions.yml
@@ -42,6 +42,10 @@ on:
 permissions:
   contents: write  # Required for creating releases
 
+concurrency:
+  group: publish-instructions-main
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #231

## Summary

- Add a top-level `concurrency` block to `.github/workflows/publish-instructions.yml`.
- Use a fixed `publish-instructions-main` concurrency group so publish workflow runs cannot overlap.
- Set `cancel-in-progress: false` so an in-progress publish is allowed to finish instead of being cancelled midway through publishing or release updates.

## Testing notes

- This is GitHub Actions workflow configuration, not application code so unit tests don't apply.
- Live concurrency behavior was not exercised because this workflow performs publishing and release operations and is triggered by main pushes or manual dispatch.
- Parsed `.github/workflows/publish-instructions.yml` successfully with `yaml.safe_load`.
- `actionlint -shellcheck= .github/workflows/publish-instructions.yml` passes.
- Full `actionlint` reports pre-existing ShellCheck warnings in unchanged `run:` blocks, those are outside the scope of this PR.

## Assumptions

- None. The fixed `publish-instructions-main` concurrency group is specified in issue #231. The fixed group also ensures both `main` push runs and manual `workflow_dispatch` runs share the same concurrency guard.