### PR TITLE
#230: Remove duplicate hooks build from CI

### DIFF
--- a/.github/workflows/ci-rosetta-hooks.yml
+++ b/.github/workflows/ci-rosetta-hooks.yml
@@ -37,10 +37,6 @@ jobs:
       working-directory: ./src/hooks
       run: npm run check
 
-    - name: Build package
-      working-directory: ./src/hooks
-      run: npm run build
-
     - name: Run tests
       working-directory: ./src/hooks
       run: npm run test


### PR DESCRIPTION
Closes #230

## Summary

- Remove the standalone `npm run build` step from `.github/workflows/ci-rosetta-hooks.yml`.
- `npm run test` already runs `npm run build:quiet` before Vitest, so the package was being built twice in the same CI job.
- `build` and `build:quiet` perform the same build, `--quiet` only suppresses per-bundle logging.
- Keep the build inside `npm test` so the test command remains self contained for both local development and CI.

## Testing notes

- `actionlint .github/workflows/ci-rosetta-hooks.yml` passes.
- The `CI Rosetta Hooks` workflow is not expected to run automatically on this PR because its `pull_request` path filter only includes `src/hooks/**`. The remaining CI commands were exercised locally with `npm run check` and `npm test`.
- Confirmed `npm test` runs `npm run build:quiet` before Vitest.

## Assumptions
- None. 