### PR TITLE
[codex] Align help-flow workflow references

### DIFF
--- a/docs/definitions/workflows.md
+++ b/docs/definitions/workflows.md
@@ -10,7 +10,7 @@
 - modernization-flow
 - adhoc-flow
 - coding-agents-prompting-flow
-- self-help-flow
+- help-flow
 - coding-flow
 - security-flow
 - requirements-authoring-flow

--- a/instructions/r3/core/workflows/help-flow.md
+++ b/instructions/r3/core/workflows/help-flow.md
@@ -5,7 +5,7 @@ tags: ["workflow"]
 baseSchema: docs/schemas/workflow.md
 ---
 
-<self_help_flow>
+<help_flow>
 
 <description_and_purpose>
 
@@ -127,10 +127,10 @@ Direct skill and subagent invocation is ONLY appropriate for targeted, self-cont
 1. Triggered when user shifts from help to action (e.g., "run that workflow", "let's do coding").
 2. `READ FLOW <selected workflow>.md` if not already loaded.
 3. Adopt acquired workflow as active flow; start from its phase 1.
-4. Self-help-flow yields control — does not wrap the adopted workflow.
+4. Help-flow yields control — does not wrap the adopted workflow.
 
 </handoff>
 
 </workflow_phases>
 
-</self_help_flow>
+</help_flow>

--- a/plugins/core-antigravity/skills/help-flow/SKILL.md
+++ b/plugins/core-antigravity/skills/help-flow/SKILL.md
@@ -3,7 +3,7 @@ name: help-flow
 description: "Help about Rosetta: explains capabilities and usage."
 ---
 
-<self_help_flow>
+<help_flow>
 
 <description_and_purpose>
 
@@ -125,10 +125,10 @@ Direct skill and subagent invocation is ONLY appropriate for targeted, self-cont
 1. Triggered when user shifts from help to action (e.g., "run that workflow", "let's do coding").
 2. `READ FLOW <selected workflow>.md` if not already loaded.
 3. Adopt acquired workflow as active flow; start from its phase 1.
-4. Self-help-flow yields control — does not wrap the adopted workflow.
+4. Help-flow yields control — does not wrap the adopted workflow.
 
 </handoff>
 
 </workflow_phases>
 
-</self_help_flow>
+</help_flow>

--- a/plugins/core-claude/workflows/help-flow.md
+++ b/plugins/core-claude/workflows/help-flow.md
@@ -5,7 +5,7 @@ tags: ["workflow"]
 baseSchema: docs/schemas/workflow.md
 ---
 
-<self_help_flow>
+<help_flow>
 
 <description_and_purpose>
 
@@ -127,10 +127,10 @@ Direct skill and subagent invocation is ONLY appropriate for targeted, self-cont
 1. Triggered when user shifts from help to action (e.g., "run that workflow", "let's do coding").
 2. `READ FLOW <selected workflow>.md` if not already loaded.
 3. Adopt acquired workflow as active flow; start from its phase 1.
-4. Self-help-flow yields control — does not wrap the adopted workflow.
+4. Help-flow yields control — does not wrap the adopted workflow.
 
 </handoff>
 
 </workflow_phases>
 
-</self_help_flow>
+</help_flow>

--- a/plugins/core-codex/.agents/skills/help-flow/SKILL.md
+++ b/plugins/core-codex/.agents/skills/help-flow/SKILL.md
@@ -5,7 +5,7 @@ tags: ["workflow"]
 baseSchema: docs/schemas/workflow.md
 ---
 
-<self_help_flow>
+<help_flow>
 
 <description_and_purpose>
 
@@ -127,10 +127,10 @@ Direct skill and subagent invocation is ONLY appropriate for targeted, self-cont
 1. Triggered when user shifts from help to action (e.g., "run that workflow", "let's do coding").
 2. `READ FLOW <selected workflow>.md` if not already loaded.
 3. Adopt acquired workflow as active flow; start from its phase 1.
-4. Self-help-flow yields control — does not wrap the adopted workflow.
+4. Help-flow yields control — does not wrap the adopted workflow.
 
 </handoff>
 
 </workflow_phases>
 
-</self_help_flow>
+</help_flow>

--- a/plugins/core-copilot-standalone/.github/prompts/help-flow.prompt.md
+++ b/plugins/core-copilot-standalone/.github/prompts/help-flow.prompt.md
@@ -5,7 +5,7 @@ tags: ["workflow"]
 baseSchema: docs/schemas/workflow.md
 ---
 
-<self_help_flow>
+<help_flow>
 
 <description_and_purpose>
 
@@ -127,10 +127,10 @@ Direct skill and subagent invocation is ONLY appropriate for targeted, self-cont
 1. Triggered when user shifts from help to action (e.g., "run that workflow", "let's do coding").
 2. `READ FLOW <selected workflow>.md` if not already loaded.
 3. Adopt acquired workflow as active flow; start from its phase 1.
-4. Self-help-flow yields control — does not wrap the adopted workflow.
+4. Help-flow yields control — does not wrap the adopted workflow.
 
 </handoff>
 
 </workflow_phases>
 
-</self_help_flow>
+</help_flow>

--- a/plugins/core-copilot/commands/help-flow.md
+++ b/plugins/core-copilot/commands/help-flow.md
@@ -5,7 +5,7 @@ tags: ["workflow"]
 baseSchema: docs/schemas/workflow.md
 ---
 
-<self_help_flow>
+<help_flow>
 
 <description_and_purpose>
 
@@ -127,10 +127,10 @@ Direct skill and subagent invocation is ONLY appropriate for targeted, self-cont
 1. Triggered when user shifts from help to action (e.g., "run that workflow", "let's do coding").
 2. `READ FLOW <selected workflow>.md` if not already loaded.
 3. Adopt acquired workflow as active flow; start from its phase 1.
-4. Self-help-flow yields control — does not wrap the adopted workflow.
+4. Help-flow yields control — does not wrap the adopted workflow.
 
 </handoff>
 
 </workflow_phases>
 
-</self_help_flow>
+</help_flow>

--- a/plugins/core-cursor-standalone/.cursor/commands/help-flow.md
+++ b/plugins/core-cursor-standalone/.cursor/commands/help-flow.md
@@ -5,7 +5,7 @@ tags: ["workflow"]
 baseSchema: docs/schemas/workflow.md
 ---
 
-<self_help_flow>
+<help_flow>
 
 <description_and_purpose>
 
@@ -127,10 +127,10 @@ Direct skill and subagent invocation is ONLY appropriate for targeted, self-cont
 1. Triggered when user shifts from help to action (e.g., "run that workflow", "let's do coding").
 2. `READ FLOW <selected workflow>.md` if not already loaded.
 3. Adopt acquired workflow as active flow; start from its phase 1.
-4. Self-help-flow yields control — does not wrap the adopted workflow.
+4. Help-flow yields control — does not wrap the adopted workflow.
 
 </handoff>
 
 </workflow_phases>
 
-</self_help_flow>
+</help_flow>

--- a/plugins/core-cursor/commands/help-flow.md
+++ b/plugins/core-cursor/commands/help-flow.md
@@ -5,7 +5,7 @@ tags: ["workflow"]
 baseSchema: docs/schemas/workflow.md
 ---
 
-<self_help_flow>
+<help_flow>
 
 <description_and_purpose>
 
@@ -127,10 +127,10 @@ Direct skill and subagent invocation is ONLY appropriate for targeted, self-cont
 1. Triggered when user shifts from help to action (e.g., "run that workflow", "let's do coding").
 2. `READ FLOW <selected workflow>.md` if not already loaded.
 3. Adopt acquired workflow as active flow; start from its phase 1.
-4. Self-help-flow yields control — does not wrap the adopted workflow.
+4. Help-flow yields control — does not wrap the adopted workflow.
 
 </handoff>
 
 </workflow_phases>
 
-</self_help_flow>
+</help_flow>


### PR DESCRIPTION
## Summary

- replace the deprecated `self-help-flow` entry in the canonical workflow list with `help-flow`
- align the active `help-flow` root tag and handoff text with its workflow name
- regenerate the seven checked-in IDE plugin copies from the R3 source

## Root cause

`help-flow` was split from the deprecated compatibility workflow, but its body retained the old `self_help_flow` wrapper and self-reference. The canonical workflow list also continued to expose only the deprecated name.

## Before / after

- Before: the workflow list pointed readers to `self-help-flow`, while `help-flow` declared `<self_help_flow>`.
- After: the list points to `help-flow`, and all source/generated copies declare `<help_flow>` and refer to Help-flow in the handoff.

## Validation

- `npx -y rosettify-plugins@latest --release r3 --deterministic-hooks false`
- verified the R3 source plus all seven generated plugin copies contain matching `name: help-flow`, `<help_flow>`, and `</help_flow>` values
- verified the canonical list contains `help-flow` and no active `self-help-flow` entry
- `git diff --cached --check`

Closes #276