### PR TITLE
fix(rosettify-prompts): reuse default Anthropic beta

### DIFF
--- a/src/rosettify-prompts/src/cli.ts
+++ b/src/rosettify-prompts/src/cli.ts
@@ -6,7 +6,7 @@ import { loadConfig } from './config.js';
 import { createAnthropicClient, createOptimizeClient, type StreamingAnthropicClient } from './anthropic-client.js';
 import { runBenchSuite } from './runner.js';
 import { buildReport, writeReportFiles } from './report.js';
-import { OPTIMIZE_STEPS, runPromptOptimization } from './optimize.js';
+import { DEFAULT_OPTIMIZE_ANTHROPIC_BETAS, OPTIMIZE_STEPS, runPromptOptimization } from './optimize.js';
 import { createTerminalAsker } from './ask.js';
 import { colorsEnabled, createPalette } from './colors.js';
 import type { JudgeMode, SupportingFile, ThinkingEffort } from './types.js';
@@ -187,7 +187,7 @@ program
         throw new Error('At least one --target file is required');
       }
       const stepLimit = opts.stepLimit ?? OPTIMIZE_STEPS.length;
-      const defaultBetas = opts.defaultAnthropicBeta ? ['thinking-token-count-2026-05-13'] : [];
+      const defaultBetas = opts.defaultAnthropicBeta ? DEFAULT_OPTIMIZE_ANTHROPIC_BETAS : [];
       const anthropicBetas = [...defaultBetas, ...opts.anthropicBeta];
       if (opts.dryRun) {
         await runPromptOptimization(

--- a/src/rosettify-prompts/src/optimize.ts
+++ b/src/rosettify-prompts/src/optimize.ts
@@ -31,7 +31,7 @@ export {
   type OptimizeSubStepId,
 } from './optimize-prompts.js';
 
-const DEFAULT_OPTIMIZE_ANTHROPIC_BETAS = ['thinking-token-count-2026-05-13'];
+export const DEFAULT_OPTIMIZE_ANTHROPIC_BETAS = ['thinking-token-count-2026-05-13'];
 const DEFAULT_EFFORT: ThinkingEffort = 'high';
 
 /** In-conversation labels for the non-content operations of the single-session pipeline. */


### PR DESCRIPTION
Fixes #273

## Summary

- export the optimizer's default Anthropic beta list
- reuse that default when the CLI builds its dry-run and execution options

This keeps the CLI preview and optimizer request on one canonical beta definition, preventing them from drifting when the default changes.

## Validation

- `npm test` (96 tests passed)
- `npm run typecheck`
- `npm run build`
- `venv/bin/python scripts/pre_commit.py` (type validation and repository test validation passed; 33 hook test files / 1,142 tests and 9 rosettify-prompts test files / 96 tests passed)

Signed-off-by: nightcityblade <nightcityblade@gmail.com>
