### PR TITLE
fix(hooks): use path-aware exclusions

### DIFF
--- a/docs/hooks-verify.md
+++ b/docs/hooks-verify.md
@@ -241,7 +241,7 @@ Matchers are internal TypeScript predicates that determine whether a hook fires 
 ```
 
 **Wiring in `run-hook.ts`:**
-- `FilePathPredicate` → checked at `evalFilePath()` — matches `ctx.filePath` against basename/extension/notContainsAny rules
+- `FilePathPredicate` → checked at `evalFilePath()` — matches `ctx.filePath` against basename/extension rules; `notStartsWithAny` is for directory roots, while raw-substring `notContainsAny` remains only for compatibility
 - `ToolInputPredicate.commandMatchWhen` → checked at `evalToolInput()` — matches `ctx.toolInput.command` against `re.test(command)`; only fires when `ctx.toolName` is in the `tools` array AND the command matches the regex
 
 **Per-hook wiring:**

--- a/src/hooks/src/hooks/lint-format-advisory.ts
+++ b/src/hooks/src/hooks/lint-format-advisory.ts
@@ -22,7 +22,7 @@ export const lintFormatAdvisoryHook = defineHook({
     toolKinds: ['write', 'edit', 'multi-edit', 'patch', 'create', 'replace'],
     filePath: {
       extOneOfCi: MONITORED_EXTENSIONS,
-      notContainsAny: [
+      notStartsWithAny: [
         'node_modules/', '.venv/', '__pycache__/',
         'dist/', 'build/', '.git/',
       ],

--- a/src/hooks/src/hooks/loose-files.ts
+++ b/src/hooks/src/hooks/loose-files.ts
@@ -32,7 +32,7 @@ export const looseFilesHook = defineHook({
     toolKinds: ['write'],
     filePath: {
       extOneOf: ['.py', '.js'],
-      notContainsAny: [
+      notStartsWithAny: [
         'agents/TEMP/', 'scripts/', 'tests/', 'validation/',
         'node_modules/', '.venv/', '__pycache__/',
       ],

--- a/src/hooks/src/runtime/types.ts
+++ b/src/hooks/src/runtime/types.ts
@@ -32,6 +32,7 @@ export type HookResult =
 export type FilePathPredicate = {
   extOneOf?:           readonly string[];
   extOneOfCi?:         readonly string[];
+  /** Raw substring exclusion retained for compatibility; prefer notStartsWithAny for directory roots. */
   notContainsAny?:     readonly string[];
   notTokenSegmentAny?: readonly string[];
   notStartsWithAny?:   readonly string[];

--- a/src/hooks/tests/lint-format-advisory.test.ts
+++ b/src/hooks/tests/lint-format-advisory.test.ts
@@ -223,16 +223,16 @@ describe('case-insensitive extension matching', () => {
   });
 });
 
-// ── integration: exclusion boundary precision (notContainsAny w/ trailing slash) ────
+// ── integration: exclusion boundary precision (notStartsWithAny) ─────────────
 //
-// Exclusions match exact substrings WITH a trailing slash (`dist/`, `build/`,
-// `node_modules/`). Directory names that merely share a prefix must NOT be
-// excluded.
+// Exclusions match directory segments (`dist/`, `build/`, `node_modules/`).
+// Directory names that merely share a prefix or suffix must NOT be excluded.
 
-describe('exclusion boundary — prefix-only matches still fire', () => {
+describe('exclusion boundary — near matches still fire', () => {
   const nearMiss = [
     'distillery/app.ts',          // `dist` ≠ `dist/`
     'builder/app.ts',             // `build` ≠ `build/`
+    'rebuild/app.ts',             // `build/` is only a suffix of the segment
     'node_modules_local/foo.ts',  // `node_modules` ≠ `node_modules/`
   ];
 

--- a/src/hooks/tests/loose-files.test.ts
+++ b/src/hooks/tests/loose-files.test.ts
@@ -163,6 +163,21 @@ describe('runHook — nudge output shape', () => {
 
 });
 
+describe('runHook — exclusion boundary precision', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  test.each(['contests/foo.py', 'latest_tests/bar.js'])(
+    'near-match directory still triggers for %s',
+    async (filePath) => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const raw = { ...ccWrite, tool_input: { ...ccWrite.tool_input, file_path: filePath } };
+      const { writable, output } = capture();
+      await runHook(looseFilesHook, { stdin: toStream(raw), stdout: writable });
+      expect(output()).not.toBe('');
+    },
+  );
+});
+
 // Platform-level dedup removed 2026-06-30 (see define-hook.ts): it existed to collapse TWO
 // invocations Copilot CLI made for a SINGLE registered hook per real event — a Copilot-side
 // runtime bug, now fixed by GitHub (confirmed empirically). Copilot no longer needs special

--- a/src/hooks/tests/runtime/run-hook.test.ts
+++ b/src/hooks/tests/runtime/run-hook.test.ts
@@ -127,6 +127,9 @@ describe('runHook — filePath predicates', () => {
   test('notStartsWithAny with absolute /proj/docs/ path → silent', async () => {
     expect(await runWithFilePath({ extOneOfCi: ['.md'], notStartsWithAny: ['docs/'] }, '/proj/docs/notes.md')).toBe(false);
   });
+  test('notStartsWithAny does not match a directory-name suffix → fires', async () => {
+    expect(await runWithFilePath({ extOneOf: ['.py'], notStartsWithAny: ['tests/'] }, 'contests/foo.py')).toBe(true);
+  });
   test('notBasenameOneOf README.md excludes → silent', async () => {
     expect(await runWithFilePath({ extOneOfCi: ['.md'], notBasenameOneOf: ['README.md'] }, 'packages/web/README.md')).toBe(false);
   });

--- a/test-library/hooks/loose-files/prompt-claude-code.md
+++ b/test-library/hooks/loose-files/prompt-claude-code.md
@@ -155,7 +155,7 @@ After this command `package.json` is back in place — subsequent tests in `<ROO
 
 **Action:** **Write** → `<ROOT>/scripts/helper-claude.js` with content `// helper`.
 
-**Expected:** silent — `scripts/` is in the hook's `notContainsAny` exclusion list.
+**Expected:** silent — `scripts/` is in the hook's `notStartsWithAny` exclusion list.
 
 **Verify & Report:** expect silent.
 

--- a/test-library/hooks/loose-files/prompt-codex.md
+++ b/test-library/hooks/loose-files/prompt-codex.md
@@ -220,7 +220,7 @@ git -C "$(git rev-parse --show-toplevel)" checkout -- package.json
 
 **Action:** **Write** → `<ROOT>/scripts/helper-codex.js` with content `// helper`.
 
-**Expected:** silent — `scripts/` is in the hook's `notContainsAny` exclusion list.
+**Expected:** silent — `scripts/` is in the hook's `notStartsWithAny` exclusion list.
 
 **Verify & Report:** expect silent.
 

--- a/test-library/hooks/loose-files/prompt-copilot.md
+++ b/test-library/hooks/loose-files/prompt-copilot.md
@@ -159,7 +159,7 @@ git -C "$(git rev-parse --show-toplevel)" checkout -- package.json
 
 **Action:** **Write** / `create_file` → `<ROOT>/scripts/helper-copilot.js` with content `// helper`.
 
-**Expected:** silent — `scripts/` is in the hook's `notContainsAny` exclusion list.
+**Expected:** silent — `scripts/` is in the hook's `notStartsWithAny` exclusion list.
 
 **Verify & Report:** expect silent.
 

--- a/test-library/hooks/loose-files/prompt-cursor.md
+++ b/test-library/hooks/loose-files/prompt-cursor.md
@@ -151,7 +151,7 @@ git -C "$(git rev-parse --show-toplevel)" checkout -- package.json
 
 **Action:** **Write** → `<ROOT>/scripts/helper-cursor.js` with content `// helper`.
 
-**Expected:** silent — `scripts/` is in the hook's `notContainsAny` exclusion list.
+**Expected:** silent — `scripts/` is in the hook's `notStartsWithAny` exclusion list.
 
 **Verify & Report:** expect silent.
 

--- a/test-library/hooks/loose-files/prompt-windsurf.md
+++ b/test-library/hooks/loose-files/prompt-windsurf.md
@@ -195,7 +195,7 @@ git -C "$(git rev-parse --show-toplevel)" checkout -- package.json
 
 **Action:** write `<ROOT>/scripts/helper-windsurf.js` with content `// helper`.
 
-**Expected:** silent — `scripts/` is in the hook's `notContainsAny` exclusion list.
+**Expected:** silent — `scripts/` is in the hook's `notStartsWithAny` exclusion list.
 
 **Verify & Report:** expect silent.
 


### PR DESCRIPTION
Fixes #270

## Summary

- use the existing path-boundary-aware exclusion predicate for the loose-file and lint/format hooks
- cover a directory-name suffix that previously matched `build/` as a raw substring

The hooks now exclude real directory segments while allowing paths such as `rebuild/app.ts` to receive the advisory.

## Validation

- `npm test` in `src/hooks` (33 test files, 1,143 tests passed)
- `npm run check` in `src/hooks`
- `venv/bin/python scripts/pre_commit.py` (repository type validation and test validation passed)

Signed-off-by: nightcityblade <nightcityblade@gmail.com>
