### PR TITLE
fix(cli): honor page size for filtered cleanup

### DIFF
--- a/src/rosetta-cli/rosetta_cli/commands/cleanup_command.py
+++ b/src/rosetta-cli/rosetta_cli/commands/cleanup_command.py
@@ -94,13 +94,13 @@ class CleanupCommand(BaseCommand):
             # Filter by tags (metadata condition)
             tags_list = self._parse_tags(args.tags)
             filtered_documents = document_service.filter_documents_by_tags(
-                dataset, tags_list
+                dataset, tags_list, limit=self.config.page_size
             )
             print(f"\nFiltered {len(filtered_documents)} document(s) with tags: {', '.join(tags_list)}\n")
         elif args.prefix:
             # Filter by prefix
             filtered_documents = document_service.filter_documents_by_prefix(
-                dataset, args.prefix
+                dataset, args.prefix, limit=self.config.page_size
             )
             print(f"\nFiltered {len(filtered_documents)} document(s) matching prefix '{args.prefix}'\n")
         else:

--- a/src/rosetta-cli/tests/test_cleanup_command.py
+++ b/src/rosetta-cli/tests/test_cleanup_command.py
@@ -1,0 +1,36 @@
+from argparse import Namespace
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from rosetta_cli.commands.cleanup_command import CleanupCommand
+
+
+@pytest.mark.parametrize(
+    ("args", "method_name", "filter_value"),
+    [
+        (
+            Namespace(tags="one,two", prefix=None),
+            "filter_documents_by_tags",
+            ["one", "two"],
+        ),
+        (Namespace(tags=None, prefix="guide-"), "filter_documents_by_prefix", "guide-"),
+    ],
+)
+def test_filtered_cleanup_uses_configured_page_size(
+    monkeypatch, args, method_name, filter_value
+):
+    document_service = Mock()
+    getattr(document_service, method_name).return_value = []
+    monkeypatch.setattr(
+        "rosetta_cli.commands.cleanup_command.DocumentService",
+        lambda client: document_service,
+    )
+    command = CleanupCommand(SimpleNamespace(), SimpleNamespace(page_size=2048))
+    dataset = SimpleNamespace()
+
+    command._get_filtered_documents(dataset, SimpleNamespace(), args)
+
+    getattr(document_service, method_name).assert_called_once_with(
+        dataset, filter_value, limit=2048
+    )


### PR DESCRIPTION
## Summary

- pass the configured `page_size` to tag- and prefix-filtered cleanup queries
- add a parametrized regression test covering both filtered branches

## Why

`cleanup-dataset --tags` and `--prefix` silently used `DocumentService`'s default limit of 1000 instead of `RAGFLOW_PAGE_SIZE`. Deployments configured above that default could therefore under-delete matching documents without warning. The unfiltered branch already honors the configured page size; this makes all three paths consistent.

## Validation

- `PYTHONPATH=src/rosetta-cli venv/bin/python -m pytest -q src/rosetta-cli/tests/test_cleanup_command.py src/rosetta-cli/tests/test_command_auth_order.py` — 5 passed
- `PYTHONPATH=src/rosetta-cli venv/bin/python -m pytest -q src/rosetta-cli/tests` — 39 passed
- `uvx ruff check src/rosetta-cli/tests/test_cleanup_command.py` — passed
- `uvx ruff check --select E9,F63,F7,F82 src/rosetta-cli/rosetta_cli/commands/cleanup_command.py` — passed
- `uvx ruff format --check src/rosetta-cli/tests/test_cleanup_command.py` — passed
- `ROSETTIFY_PLUGINS_LOG_LEVEL=warn venv/bin/python scripts/pre_commit.py` — passed

## Checklist

- [x] Scope is narrow and explicit
- [x] New behavior has regression coverage
- [x] Local validation passes
- [x] Commit includes the required DCO sign-off

AI assistance was used to inspect the issue, implement the focused change, and run validation. I reviewed every changed line.

Closes #267
