### PR TITLE
docs: update MCP server version defaults

### DIFF
--- a/src/rosetta-mcp-server/README.md
+++ b/src/rosetta-mcp-server/README.md
@@ -66,7 +66,7 @@ Rosetta MCP supports two runtime modes:
 |----------|-------|---------|-------|
 | `ROSETTA_SERVER_URL` | Runtime (all modes) | `https://<production server URL>/` | Rosetta Server base URL |
 | `ROSETTA_API_KEY` | Runtime (all modes) | Empty | Required for Rosetta Server access |
-| `VERSION` | Runtime (all modes) | `r1` | Used for instruction dataset resolution (`aia-{version}`) |
+| `VERSION` | Runtime (all modes) | `r3` | Used for instruction dataset resolution (`aia-{version}`) |
 | `ROSETTA_TRANSPORT` | Runtime (all modes) | `stdio` | `stdio` or `http` |
 | `ROSETTA_HTTP_HOST` | Runtime (HTTP) | `0.0.0.0` | HTTP bind host |
 | `ROSETTA_HTTP_PORT` | Runtime (HTTP) | `8000` | HTTP bind port |
@@ -106,7 +106,7 @@ Rosetta MCP supports two runtime modes:
 |----------|-------------|---------|
 | `ROSETTA_SERVER_URL` | Rosetta Server base URL | `https://<production server URL>/` |
 | `ROSETTA_API_KEY` | API key used by Rosetta MCP to access Rosetta Server | Required |
-| `VERSION` | Instruction release used for instruction dataset resolution (`aia-{version}`) | `r1` |
+| `VERSION` | Instruction release used for instruction dataset resolution (`aia-{version}`) | `r3` |
 | `ROSETTA_DEBUG` | Enable debug logging to stderr (`1/true/yes/on`); legacy alias `IMS_DEBUG` still honored | Disabled |
 | `FASTMCP_LOG_LEVEL` | Set to `DEBUG` alongside `ROSETTA_DEBUG=1` for full FastMCP internals | `INFO` |
 | `FASTMCP_ENABLE_RICH_LOGGING` | Set to `false` to disable Rich formatting (use in production/Grafana) | `true` |


### PR DESCRIPTION
## Summary

- update both MCP server README tables to show the active `r3` default for `VERSION`
- keep deployment guidance consistent with `DEFAULT_VERSION` in the runtime constants

Fixes #258

## Validation

- `venv/bin/python scripts/pre_commit.py`
  - hooks build and plugin sync passed
  - type validation passed
  - MCP server, CLI, and hooks tests passed (1,142 hooks tests)
- `git diff --check`

## AI assistance

AI assistance was used for this focused documentation change. I reviewed the complete diff and ran the repository's mandatory full pre-commit gate.
