### PR TITLE
fix(rosettify): validate plan names on writes

### DIFF
--- a/src/rosettify/src/commands/plan/core.ts
+++ b/src/rosettify/src/commands/plan/core.ts
@@ -383,8 +383,8 @@ export function validateDependencies(plan: Plan): string | null {
 export function validateSizeLimits(plan: Plan): string | null {
   if ((plan.phases ?? []).length > PLAN_MAX_PHASES) return "size_limit_exceeded";
 
-  if (plan.name && plan.name.length > PLAN_MAX_NAME_LENGTH)
-    return "size_limit_exceeded";
+  const nameErr = validatePlanName(plan.name);
+  if (nameErr) return nameErr;
 
   function checkStringLength(value: unknown): boolean {
     if (typeof value === "string" && value.length > PLAN_MAX_STRING_LENGTH)

--- a/src/rosettify/src/commands/plan/core.ts
+++ b/src/rosettify/src/commands/plan/core.ts
@@ -305,8 +305,8 @@ export function depsSatisfied(
 // Validation Functions
 // ---------------------------------------------------------------------------
 
-export function validatePlanName(name: string): string | null {
-  if (!name || !name.trim()) return "size_limit_exceeded";
+export function validatePlanName(name: unknown): string | null {
+  if (typeof name !== "string" || !name.trim()) return "size_limit_exceeded";
   if (name.length > PLAN_MAX_NAME_LENGTH) return "size_limit_exceeded";
   return null;
 }

--- a/src/rosettify/tests/unit/plan/create.test.ts
+++ b/src/rosettify/tests/unit/plan/create.test.ts
@@ -124,6 +124,14 @@ describe("cmdCreate — FR-PLAN-0010 / FR-PLAN-0040", () => {
     expect(tree.plan.name).toBe("Unnamed Plan");
   });
 
+  it.each(["", "   "])("rejects an empty plan name %#", async (name) => {
+    const file = planFile();
+    const result = await cmdCreate(file, { name });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("size_limit_exceeded");
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
   it("rejects plan with duplicate ids", async () => {
     const file = planFile();
     const data = {

--- a/src/rosettify/tests/unit/plan/create.test.ts
+++ b/src/rosettify/tests/unit/plan/create.test.ts
@@ -124,7 +124,7 @@ describe("cmdCreate — FR-PLAN-0010 / FR-PLAN-0040", () => {
     expect(tree.plan.name).toBe("Unnamed Plan");
   });
 
-  it.each(["", "   "])("rejects an empty plan name %#", async (name) => {
+  it.each(["", "   ", 123, {}])("rejects an invalid plan name %#", async (name) => {
     const file = planFile();
     const result = await cmdCreate(file, { name });
     expect(result.ok).toBe(false);

--- a/src/rosettify/tests/unit/plan/upsert.test.ts
+++ b/src/rosettify/tests/unit/plan/upsert.test.ts
@@ -124,7 +124,7 @@ describe("cmdUpsert — entire_plan on existing file (merge)", () => {
     expect(plan.name).toBe("Test Plan"); // unchanged
   });
 
-  it.each(["", "   "])("rejects an empty plan name %#", async (name) => {
+  it.each(["", "   ", 123, {}])("rejects an invalid plan name %#", async (name) => {
     const file = writePlan();
     const result = await cmdUpsert(file, "entire_plan", { name });
     expect(result.ok).toBe(false);

--- a/src/rosettify/tests/unit/plan/upsert.test.ts
+++ b/src/rosettify/tests/unit/plan/upsert.test.ts
@@ -124,6 +124,14 @@ describe("cmdUpsert — entire_plan on existing file (merge)", () => {
     expect(plan.name).toBe("Test Plan"); // unchanged
   });
 
+  it.each(["", "   "])("rejects an empty plan name %#", async (name) => {
+    const file = writePlan();
+    const result = await cmdUpsert(file, "entire_plan", { name });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("size_limit_exceeded");
+    expect(loadPlan(file)!.name).toBe("Test Plan");
+  });
+
   it("merges phases by id", async () => {
     const file = writePlan();
     const result = await cmdUpsert(file, "entire_plan", {

--- a/src/rosettify/tests/unit/shared/core-utils.test.ts
+++ b/src/rosettify/tests/unit/shared/core-utils.test.ts
@@ -240,6 +240,10 @@ describe("validatePlanName", () => {
     expect(validatePlanName("   ")).toBe("size_limit_exceeded");
   });
 
+  it.each([123, {}])("returns error for non-string name %#", (name) => {
+    expect(validatePlanName(name)).toBe("size_limit_exceeded");
+  });
+
   it("returns error for name exceeding 256 chars", () => {
     expect(validatePlanName("x".repeat(257))).toBe("size_limit_exceeded");
   });

--- a/src/rosettify/tests/unit/shared/core-utils.test.ts
+++ b/src/rosettify/tests/unit/shared/core-utils.test.ts
@@ -502,6 +502,12 @@ describe("validateSizeLimits", () => {
     expect(validateSizeLimits(fullPlan())).toBeNull();
   });
 
+  it.each(["", "   "])("rejects an empty plan name %#", (name) => {
+    const plan = fullPlan();
+    plan.name = name;
+    expect(validateSizeLimits(plan)).toBe("size_limit_exceeded");
+  });
+
   it("returns size_limit_exceeded for plan name > 256", () => {
     const plan = fullPlan();
     plan.name = "x".repeat(257);


### PR DESCRIPTION
## Summary

- route the shared plan write validation through the existing `validatePlanName` helper
- reject empty and whitespace-only names on both create and upsert paths
- preserve the existing `Unnamed Plan` default when a name is omitted
- add regression coverage for the validator and both write paths

## Why

`validatePlanName` already enforced the required non-empty plan name, but the create and upsert paths only called `validateSizeLimits`. Its truthy length guard allowed empty or whitespace-only names to be written. Reusing the existing helper in the shared validation path keeps the name rules in one place.

## Validation

- targeted: 3 files, 114 tests passed
- `npm run typecheck`
- `npm test` — 60 files, 1,572 tests passed
- `git diff --check`

Fixes #225

## Checklist

- [x] Scope is narrow and explicit
- [x] Existing omitted-name behavior is preserved
- [x] New behavior has regression coverage
- [x] Local component validation passes
- [x] Commit includes the required DCO sign-off

## AI assistance

AI assistance was used to inspect the issue, implement the focused change, and run validation. I reviewed every changed line.
