### PR TITLE
Remove dead _validate_topic function

### DIFF
--- a/src/rosetta-mcp-server/rosetta_mcp/server.py
+++ b/src/rosetta-mcp-server/rosetta_mcp/server.py
@@ -542,13 +542,6 @@ async def _build_call_context(tool_name: str, params: dict[str, Any], ctx: Conte
     )
 
 
-def _validate_topic(topic: str | None) -> str | None:
-    # >10 is intentional: AI will always add more words, gives extra word buffer
-    if topic and len(topic.split()) > 10:
-        return "Error: topic must be 10 words or less"
-    return None
-
-
 # This is required, as sometimes models hallucinate tags as single string, but we don't want tool contract to be different (as it causes more hallucinations)
 def _normalize_tags(tags: list[str] | str | None) -> tuple[list[str] | None, str | None]:
     """Normalize single-string or list tag input for tool wrappers."""


### PR DESCRIPTION
Fixes #256.

\`_validate_topic\` (\`src/rosetta-mcp-server/rosetta_mcp/server.py:545\`)
has zero call sites in \`src/\`. Both places that could use it
(\`get_context_instructions\`, \`query_instructions\`) hardcode
\`topic=None\` with an inline comment explaining topic filtering was
intentionally disabled to reduce noise. Leaving the validator in place
implies topic filtering is still active, which is misleading -- removed
per the issue's own preferred option (YAGNI) and the automated triage
comment's recommendation.

Verified: grepped for every reference to \`_validate_topic\` before and
after -- only the definition existed, confirming this is genuinely dead
code, not something with a hidden caller. Full test suite: 334/334
passing, no regressions.