### PR TITLE
fix(hooks): detect git branch force-delete flag variants

### DIFF
--- a/src/hooks/src/hooks/dangerous-actions/patterns.ts
+++ b/src/hooks/src/hooks/dangerous-actions/patterns.ts
@@ -94,6 +94,16 @@ const GIT_FORCE_FLAG_LA = String.raw`(?=(?:\s+\S+)*\s+(?:-f\b|--force(?!-with-le
 // argument, not a refspec) is left alone and handled separately.
 const GIT_FORCE_REFSPEC_LA = String.raw`(?=(?:\s+-\S+)*\s+(?!-)(?!['"]?\+)\S+(?:\s+\S+)*\s+['"]?\+\S)`;
 
+// `git branch` force-delete detection. `-D` is shorthand for `--delete --force`.
+// Git also accepts delete + force as separate short/long flags, in either order,
+// and as combined short flags (`-df` / `-fd`). Keep the delete and force checks
+// independent so ordinary `-d` / `--delete` remains outside this guardrail.
+// Lookaheads stop at common shell command separators so a later command cannot
+// accidentally supply the missing force/delete flag for an earlier branch command.
+const GIT_BRANCH = String.raw`\bgit\s+branch\b`;
+const GIT_BRANCH_DELETE_LA = String.raw`(?=[^;&|\r\n]*(?:\s--delete\b|\s-[a-zA-Z]*[dD][a-zA-Z]*\b))`;
+const GIT_BRANCH_FORCE_LA = String.raw`(?=[^;&|\r\n]*(?:\s--force\b|\s-[a-zA-Z]*[fD][a-zA-Z]*\b))`;
+
 export const DANGEROUS_BASH: readonly DangerPattern[] = [
   { id: 'rm-rf-root',          re: new RegExp(String.raw`\brm\b` + RM_RF_GUARD + RM_ROOT_TARGET),              label: 'rm -rf /',              reason: REASON.FILE_DELETION,         policy: 'reconsider' },
   { id: 'rm-rf-home',          re: new RegExp(String.raw`\brm\b` + RM_RF_GUARD + RM_HOME_TARGET),              label: 'rm -rf $HOME',          reason: REASON.FILE_DELETION,         policy: 'reconsider' },
@@ -107,7 +117,7 @@ export const DANGEROUS_BASH: readonly DangerPattern[] = [
   { id: 'git-force-push',      re: new RegExp(GIT_PUSH + `(?:${GIT_FORCE_FLAG_LA}|${GIT_FORCE_REFSPEC_LA})`),  label: 'git push --force',      reason: REASON.GIT_HISTORY_REWRITE,   policy: 'reconsider' },
   { id: 'git-reset-hard',      re: /\bgit\s+reset\s+--hard\b/,                                                 label: 'git reset --hard',      reason: REASON.GIT_HISTORY_REWRITE,   policy: 'reconsider' },
   { id: 'git-clean-force',     re: /\bgit\s+clean\s+-[a-z]*[fd]/,                                              label: 'git clean -fd',         reason: REASON.FILE_DELETION,         policy: 'reconsider' },
-  { id: 'git-branch-delete',   re: /\bgit\s+branch\s+-D\b/,                                                    label: 'git branch -D',         reason: REASON.GIT_HISTORY_REWRITE,   policy: 'reconsider' },
+  { id: 'git-branch-delete',   re: new RegExp(GIT_BRANCH + GIT_BRANCH_DELETE_LA + GIT_BRANCH_FORCE_LA),         label: 'git branch -D',         reason: REASON.GIT_HISTORY_REWRITE,   policy: 'reconsider' },
   { id: 'aws-s3-rm-recursive', re: /\baws\s+s3\s+rm\b.*--recursive\b/,                                         label: 'aws s3 rm --recursive', reason: REASON.FILE_DELETION,         policy: 'reconsider' },
   { id: 'kubectl-delete-prod', re: /\bkubectl\s+delete\b.*--all\b/,                                            label: 'kubectl mass delete',   reason: REASON.INFRA_OPERATION,       policy: 'reconsider' },
   { id: 'dropdb',              re: /\b(?:dropdb\b|psql\b[^"']*\bdrop\s+(?:table|database|schema)\b)/i,         label: 'DB drop CLI',           reason: REASON.SCHEMA_MODIFICATION,   policy: 'reconsider' },

--- a/src/hooks/tests/git-branch-delete.test.ts
+++ b/src/hooks/tests/git-branch-delete.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'vitest';
+import { DANGEROUS_BASH } from '../src/hooks/dangerous-actions/patterns';
+import { evaluateDangerous } from '../src/hooks/dangerous-actions/evaluate';
+import type { HookContext } from '../src/runtime/types';
+
+const branchDelete = DANGEROUS_BASH.find((pattern) => pattern.id === 'git-branch-delete')!.re;
+
+const bashCtx = (command: string): HookContext => ({
+  ide: 'claude-code',
+  event: 'PreToolUse',
+  toolKind: 'bash',
+  toolName: 'Bash',
+  filePath: '',
+  cwd: '/proj',
+  sessionId: null,
+  toolInput: { command },
+});
+
+const forceDeleteVariants = [
+  'git branch -D throwaway-test',
+  'git branch -d -f throwaway-test',
+  'git branch -f -d throwaway-test',
+  'git branch -fd throwaway-test',
+  'git branch -df throwaway-test',
+  'git branch --delete --force throwaway-test',
+  'git branch --force --delete throwaway-test',
+  'git branch -d --force throwaway-test',
+  'git branch --delete -f throwaway-test',
+] as const;
+
+describe('git-branch-delete dangerous-action guard', () => {
+  for (const command of forceDeleteVariants) {
+    test(`${command} matches the guard`, () => {
+      expect(branchDelete.test(command)).toBe(true);
+    });
+
+    test(`${command} is reconsidered without the review marker`, () => {
+      const result = evaluateDangerous(bashCtx(command));
+      expect(result?.kind).toBe('deny');
+      expect((result as { kind: 'deny'; reason: string }).reason).toContain('git-branch-delete');
+    });
+
+    test(`${command} is allowed with the review marker`, () => {
+      expect(
+        evaluateDangerous(bashCtx(`${command}  # Rosetta-AI-reviewed`)),
+      ).toBeNull();
+    });
+  }
+
+  test.each([
+    'git branch -d throwaway-test',
+    'git branch --delete throwaway-test',
+    'git branch -f throwaway-test',
+    'git branch --force throwaway-test',
+    'git branch --list',
+    'git branch --show-current',
+  ])('%s stays outside the force-delete guard', (command) => {
+    expect(branchDelete.test(command)).toBe(false);
+  });
+
+  test('a later shell command cannot supply the missing force flag', () => {
+    expect(branchDelete.test('git branch -d throwaway-test && echo --force')).toBe(false);
+  });
+
+  test('a later shell command cannot supply the missing delete flag', () => {
+    expect(branchDelete.test('git branch -f throwaway-test; echo --delete')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #296

## Why

The `git-branch-delete` guard only recognized literal `git branch -D`, even though Git accepts equivalent force-delete forms such as `-d -f`, `-fd`, `-df`, and `--delete --force`.

Those variants could bypass the existing `reconsider` safety guard.

## What changed

- split `git branch` force-delete detection into independent delete + force checks
- support short, long, separate, mixed, and reordered flag forms
- preserve ordinary non-force `git branch -d` / `--delete` behavior
- bound detection at common shell command separators so a later command cannot supply the missing force/delete flag
- add focused regression coverage for:
  - force-delete variants
  - `evaluateDangerous()` deny behavior
  - `# Rosetta-AI-reviewed` override behavior
  - safe non-force commands
  - cross-command false positives

## Scope

Two files only:

- `src/hooks/src/hooks/dangerous-actions/patterns.ts`
- `src/hooks/tests/git-branch-delete.test.ts`

No unrelated refactor or guardrail-policy changes.

## Validation

- isolated executable detector matrix: **20/20 passed**
- based on current upstream `main` at `fca6be111aec87c55c877047184f723d671d3598`
- both commits include DCO `Signed-off-by` trailers

The full repository dependency/test suite could not be executed from the ChatGPT tool environment because that runtime cannot fetch the repository's npm dependencies. The change was instead kept narrowly scoped and validated against the relevant behavior directly.

## Risk / behavior boundary

This only broadens the existing `git-branch-delete` `reconsider` guard to equivalent force-delete syntax.

It does not introduce a hard-deny path, and normal non-force branch deletion remains unguarded as before.

AI assistance was used to implement and review this change. I reviewed and take responsibility for the submitted diff, consistent with the repository's AI-assisted contribution policy.