### PR TITLE
ci: serialize package publish workflows

### DIFF
--- a/.github/scripts/test_publish_workflow_concurrency.py
+++ b/.github/scripts/test_publish_workflow_concurrency.py
@@ -1,0 +1,45 @@
+"""Regression checks for package-publish workflow concurrency policies."""
+
+from pathlib import Path
+
+import yaml
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPOSITORY_ROOT / ".github" / "workflows"
+
+
+def load_workflow(name: str) -> dict:
+    return yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+
+
+def test_helm_chart_validation_and_publish_use_separate_concurrency_groups() -> None:
+    workflow = load_workflow("publish-mcp-helm-chart.yml")
+
+    assert "concurrency" not in workflow
+    assert workflow["jobs"]["validate"]["concurrency"] == {
+        "group": "${{ github.workflow }}-${{ github.ref }}",
+        "cancel-in-progress": True,
+    }
+    assert workflow["jobs"]["publish"]["concurrency"] == {
+        "group": "publish-mcp-helm-chart-main",
+        "cancel-in-progress": False,
+    }
+
+
+def test_other_package_publish_workflows_serialize_releases() -> None:
+    expected_groups = {
+        "publish-curiocity.yml": "publish-curiocity-main",
+        "publish-ims-mcp.yml": "publish-ims-mcp-main",
+        "publish-rosetta-cli.yml": "publish-rosetta-cli-main",
+        "publish-rosetta-mcp.yml": "publish-rosetta-mcp-main",
+        "publish-rosettify.yml": "publish-rosettify-main",
+        "publish-rosettify-plugins.yml": "publish-rosettify-plugins-main",
+        "publish-rosettify-prompts.yml": "publish-rosettify-prompts-main",
+    }
+
+    for workflow_name, group in expected_groups.items():
+        workflow = load_workflow(workflow_name)
+        assert workflow["concurrency"] == {
+            "group": group,
+            "cancel-in-progress": False,
+        }

--- a/.github/workflows/publish-curiocity.yml
+++ b/.github/workflows/publish-curiocity.yml
@@ -8,6 +8,11 @@ on:
       - 'src/curiocity/**'
   workflow_dispatch:
 
+
+concurrency:
+  group: publish-curiocity-main
+  cancel-in-progress: false
+
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
@@ -87,3 +92,4 @@ jobs:
         echo ""
         echo "Install with: npm install -g curiocity@${{ steps.check_version.outputs.version }}"
         echo "Or with npx: npx -y curiocity@latest"
+

--- a/.github/workflows/publish-curiocity.yml
+++ b/.github/workflows/publish-curiocity.yml
@@ -92,4 +92,3 @@ jobs:
         echo ""
         echo "Install with: npm install -g curiocity@${{ steps.check_version.outputs.version }}"
         echo "Or with npx: npx -y curiocity@latest"
-

--- a/.github/workflows/publish-ims-mcp.yml
+++ b/.github/workflows/publish-ims-mcp.yml
@@ -124,4 +124,3 @@ jobs:
         echo ""
         echo "Install with: pip install ims-mcp==${{ steps.check_version.outputs.version }}"
         echo "Or with uvx: uvx ims-mcp"
-

--- a/.github/workflows/publish-ims-mcp.yml
+++ b/.github/workflows/publish-ims-mcp.yml
@@ -8,6 +8,11 @@ on:
       - 'src/ims-mcp-server/**'
   workflow_dispatch:
 
+
+concurrency:
+  group: publish-ims-mcp-main
+  cancel-in-progress: false
+
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
@@ -119,3 +124,4 @@ jobs:
         echo ""
         echo "Install with: pip install ims-mcp==${{ steps.check_version.outputs.version }}"
         echo "Or with uvx: uvx ims-mcp"
+

--- a/.github/workflows/publish-instructions.yml
+++ b/.github/workflows/publish-instructions.yml
@@ -220,4 +220,3 @@ jobs:
           else
             echo "**Status:** Publishing failed" >> $GITHUB_STEP_SUMMARY
           fi
-

--- a/.github/workflows/publish-instructions.yml
+++ b/.github/workflows/publish-instructions.yml
@@ -46,11 +46,6 @@ concurrency:
   group: publish-instructions-main
   cancel-in-progress: false
 
-
-concurrency:
-  group: publish-instructions-main
-  cancel-in-progress: false
-
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-instructions.yml
+++ b/.github/workflows/publish-instructions.yml
@@ -46,6 +46,11 @@ concurrency:
   group: publish-instructions-main
   cancel-in-progress: false
 
+
+concurrency:
+  group: publish-instructions-main
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -220,3 +225,4 @@ jobs:
           else
             echo "**Status:** Publishing failed" >> $GITHUB_STEP_SUMMARY
           fi
+

--- a/.github/workflows/publish-mcp-helm-chart.yml
+++ b/.github/workflows/publish-mcp-helm-chart.yml
@@ -12,6 +12,11 @@ on:
 
   workflow_dispatch:
 
+
+concurrency:
+  group: publish-mcp-helm-chart-main
+  cancel-in-progress: false
+
 jobs:
   validate:
     permissions:
@@ -67,3 +72,4 @@ jobs:
             -u "${{ secrets.DOCKERHUB_LOGIN }}" \
             --password-stdin
           helm push "./${PKG}" "oci://${REPOSITORY}"
+

--- a/.github/workflows/publish-mcp-helm-chart.yml
+++ b/.github/workflows/publish-mcp-helm-chart.yml
@@ -12,16 +12,14 @@ on:
 
   workflow_dispatch:
 
-
-concurrency:
-  group: publish-mcp-helm-chart-main
-  cancel-in-progress: false
-
 jobs:
   validate:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
@@ -47,6 +45,9 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    concurrency:
+      group: publish-mcp-helm-chart-main
+      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
@@ -72,4 +73,3 @@ jobs:
             -u "${{ secrets.DOCKERHUB_LOGIN }}" \
             --password-stdin
           helm push "./${PKG}" "oci://${REPOSITORY}"
-

--- a/.github/workflows/publish-rosetta-cli.yml
+++ b/.github/workflows/publish-rosetta-cli.yml
@@ -92,4 +92,3 @@ jobs:
         echo ""
         echo "Install with: pip install rosetta-cli==${{ steps.check_version.outputs.version }}"
         echo "Or with uvx: uvx rosetta-cli@latest"
-

--- a/.github/workflows/publish-rosetta-cli.yml
+++ b/.github/workflows/publish-rosetta-cli.yml
@@ -9,6 +9,11 @@ on:
       - 'requirements.txt'
   workflow_dispatch:
 
+
+concurrency:
+  group: publish-rosetta-cli-main
+  cancel-in-progress: false
+
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
@@ -87,3 +92,4 @@ jobs:
         echo ""
         echo "Install with: pip install rosetta-cli==${{ steps.check_version.outputs.version }}"
         echo "Or with uvx: uvx rosetta-cli@latest"
+

--- a/.github/workflows/publish-rosetta-mcp.yml
+++ b/.github/workflows/publish-rosetta-mcp.yml
@@ -120,4 +120,3 @@ jobs:
         echo ""
         echo "Install with: pip install rosetta-mcp==${{ steps.check_version.outputs.version }}"
         echo "Or with uvx: uvx rosetta-mcp"
-

--- a/.github/workflows/publish-rosetta-mcp.yml
+++ b/.github/workflows/publish-rosetta-mcp.yml
@@ -9,6 +9,11 @@ on:
       - 'requirements.txt'
   workflow_dispatch:
 
+
+concurrency:
+  group: publish-rosetta-mcp-main
+  cancel-in-progress: false
+
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
@@ -115,3 +120,4 @@ jobs:
         echo ""
         echo "Install with: pip install rosetta-mcp==${{ steps.check_version.outputs.version }}"
         echo "Or with uvx: uvx rosetta-mcp"
+

--- a/.github/workflows/publish-rosettify-plugins.yml
+++ b/.github/workflows/publish-rosettify-plugins.yml
@@ -92,4 +92,3 @@ jobs:
         echo ""
         echo "Install with: npm install -g rosettify-plugins@${{ steps.check_version.outputs.version }}"
         echo "Or with npx: npx -y rosettify-plugins@latest"
-

--- a/.github/workflows/publish-rosettify-plugins.yml
+++ b/.github/workflows/publish-rosettify-plugins.yml
@@ -8,6 +8,11 @@ on:
       - 'src/rosettify-plugins/**'
   workflow_dispatch:
 
+
+concurrency:
+  group: publish-rosettify-plugins-main
+  cancel-in-progress: false
+
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
@@ -87,3 +92,4 @@ jobs:
         echo ""
         echo "Install with: npm install -g rosettify-plugins@${{ steps.check_version.outputs.version }}"
         echo "Or with npx: npx -y rosettify-plugins@latest"
+

--- a/.github/workflows/publish-rosettify-prompts.yml
+++ b/.github/workflows/publish-rosettify-prompts.yml
@@ -92,4 +92,3 @@ jobs:
         echo ""
         echo "Install with: npm install -g rosettify-prompts@${{ steps.check_version.outputs.version }}"
         echo "Or with npx: npx -y rosettify-prompts@latest"
-

--- a/.github/workflows/publish-rosettify-prompts.yml
+++ b/.github/workflows/publish-rosettify-prompts.yml
@@ -8,6 +8,11 @@ on:
       - 'src/rosettify-prompts/**'
   workflow_dispatch:
 
+
+concurrency:
+  group: publish-rosettify-prompts-main
+  cancel-in-progress: false
+
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
@@ -87,3 +92,4 @@ jobs:
         echo ""
         echo "Install with: npm install -g rosettify-prompts@${{ steps.check_version.outputs.version }}"
         echo "Or with npx: npx -y rosettify-prompts@latest"
+

--- a/.github/workflows/publish-rosettify.yml
+++ b/.github/workflows/publish-rosettify.yml
@@ -94,4 +94,3 @@ jobs:
         echo ""
         echo "Install with: npm install -g rosettify@${{ steps.check_version.outputs.version }}"
         echo "Or with npx: npx -y rosettify@latest"
-

--- a/.github/workflows/publish-rosettify.yml
+++ b/.github/workflows/publish-rosettify.yml
@@ -8,6 +8,11 @@ on:
       - 'src/rosettify/**'
   workflow_dispatch:
 
+
+concurrency:
+  group: publish-rosettify-main
+  cancel-in-progress: false
+
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
@@ -89,3 +94,4 @@ jobs:
         echo ""
         echo "Install with: npm install -g rosettify@${{ steps.check_version.outputs.version }}"
         echo "Or with npx: npx -y rosettify@latest"
+


### PR DESCRIPTION
## Summary

Closes #298.

The package publishing workflows could start concurrently when consecutive commits touched the same package path. This can race on package versions or produce redundant registry publishes.

## Changes

- Add workflow-specific, uncancellable concurrency groups to the eight package publishing workflows missing release guards.
- Split the Helm chart workflow by job: `validate` cancels stale runs per ref, while `publish` queues releases in its own uncancellable group.

## Compatibility

Existing triggers, jobs, permissions, and release behavior are unchanged. Overlapping package releases now queue per workflow; stale Helm validation runs on the same ref are canceled without affecting a pending release.

## Validation

- `python -m pytest .github/scripts/test_publish_workflow_concurrency.py -q`
- `python -m pytest .github/scripts -q`
- Parsed all 25 workflow files with PyYAML.
- `git diff --check`