### PR TITLE
#227: Add async bundling to prevent document downloads from blocking the event loop

### DIFF
--- a/src/rosetta-mcp-server/rosetta_mcp/services/bundler.py
+++ b/src/rosetta-mcp-server/rosetta_mcp/services/bundler.py
@@ -214,44 +214,47 @@ class Bundler:
     def bundle(self, documents: list[DocumentLike], dataset_name: str, *, strip_frontmatter: bool = False) -> str:
         chunks: list[str] = []
         for doc in sorted(documents, key=self._sort_key):
-            tags_attr = self._tags_attr(doc)
-            path = self._resource_path(doc)
             body = self._documents.download_content(doc)
-            if strip_frontmatter:
-                body = self._strip_frontmatter(body)
-            chunks.append(
-                XML_FILE_OPEN.format(
-                    id=self._xml_attr(doc.id),
-                    dataset=self._xml_attr(dataset_name),
-                    path=self._xml_attr(path),
-                    name=self._xml_attr(doc.name or ""),
-                    tags=self._xml_attr(tags_attr),
-                )
+            xml_document = self._bundle_document_chunks(
+                doc,
+                dataset_name,
+                body,
+                strip_frontmatter=strip_frontmatter,
             )
-            chunks.append(body)
-            chunks.append(XML_FILE_CLOSE)
+            chunks.extend(xml_document)
         return "\n".join(chunks)
 
     async def bundle_async(self, documents: list[DocumentLike], dataset_name: str, *, strip_frontmatter: bool = False) -> str:
         chunks: list[str] = []
         for doc in sorted(documents, key=self._sort_key):
-            tags_attr = self._tags_attr(doc)
-            path = self._resource_path(doc)
             body = await offload(self._documents.download_content, doc)
-            if strip_frontmatter:
-                body = self._strip_frontmatter(body)
-            chunks.append(
-                XML_FILE_OPEN.format(
-                    id=self._xml_attr(doc.id),
-                    dataset=self._xml_attr(dataset_name),
-                    path=self._xml_attr(path),
-                    name=self._xml_attr(doc.name or ""),
-                    tags=self._xml_attr(tags_attr),
-                )
+            xml_document = self._bundle_document_chunks(
+                doc,
+                dataset_name,
+                body,
+                strip_frontmatter=strip_frontmatter,
             )
-            chunks.append(body)
-            chunks.append(XML_FILE_CLOSE)
+            chunks.extend(xml_document)
         return "\n".join(chunks)
+
+    @classmethod
+    def _bundle_document_chunks(cls, doc: DocumentLike, dataset_name: str, body: str, strip_frontmatter: bool = False) -> list[str]:
+        tags_attr = cls._tags_attr(doc)
+        path = cls._resource_path(doc)
+
+        if strip_frontmatter:
+            body = cls._strip_frontmatter(body)
+        return [
+            XML_FILE_OPEN.format(
+                id=cls._xml_attr(doc.id),
+                dataset=cls._xml_attr(dataset_name),
+                path=cls._xml_attr(path),
+                name=cls._xml_attr(doc.name or ""),
+                tags=cls._xml_attr(tags_attr),
+            ),
+            body,
+            XML_FILE_CLOSE,
+        ]
 
     def format_as_listing(self, documents: list[DocumentLike], dataset_name: str) -> str:
         """Format documents as a flat listing without content (file entries only)."""

--- a/src/rosetta-mcp-server/rosetta_mcp/services/bundler.py
+++ b/src/rosetta-mcp-server/rosetta_mcp/services/bundler.py
@@ -23,6 +23,7 @@ from rosetta_mcp.constants import (
     XML_FRONTMATTER_OPEN,
 )
 from rosetta_mcp.typing_utils import DocumentLike, JsonObject, JsonValue, as_json_object
+from rosetta_mcp.tracing import offload
 
 
 class Bundler:
@@ -216,6 +217,27 @@ class Bundler:
             tags_attr = self._tags_attr(doc)
             path = self._resource_path(doc)
             body = self._documents.download_content(doc)
+            if strip_frontmatter:
+                body = self._strip_frontmatter(body)
+            chunks.append(
+                XML_FILE_OPEN.format(
+                    id=self._xml_attr(doc.id),
+                    dataset=self._xml_attr(dataset_name),
+                    path=self._xml_attr(path),
+                    name=self._xml_attr(doc.name or ""),
+                    tags=self._xml_attr(tags_attr),
+                )
+            )
+            chunks.append(body)
+            chunks.append(XML_FILE_CLOSE)
+        return "\n".join(chunks)
+
+    async def bundle_async(self, documents: list[DocumentLike], dataset_name: str, *, strip_frontmatter: bool = False) -> str:
+        chunks: list[str] = []
+        for doc in sorted(documents, key=self._sort_key):
+            tags_attr = self._tags_attr(doc)
+            path = self._resource_path(doc)
+            body = await offload(self._documents.download_content, doc)
             if strip_frontmatter:
                 body = self._strip_frontmatter(body)
             chunks.append(

--- a/src/rosetta-mcp-server/rosetta_mcp/tools/instructions.py
+++ b/src/rosetta-mcp-server/rosetta_mcp/tools/instructions.py
@@ -280,7 +280,7 @@ async def query_instructions(
         )
         return header + "\n" + bundler.format_as_listing(docs, dataset_name)
 
-    return bundler.bundle(docs, dataset_name, strip_frontmatter=_strip_frontmatter_content)
+    return await bundler.bundle_async(docs, dataset_name, strip_frontmatter=_strip_frontmatter_content)
 
 
 async def list_instructions(

--- a/src/rosetta-mcp-server/rosetta_mcp/tools/resources.py
+++ b/src/rosetta-mcp-server/rosetta_mcp/tools/resources.py
@@ -85,4 +85,4 @@ async def read_instruction_resource(
             trace_id,
         )
         return f"Error: No documents found for resource path: {normalized_path}"
-    return bundler.bundle(docs, dataset_name)
+    return await bundler.bundle_async(docs, dataset_name)

--- a/src/rosetta-mcp-server/tests/test_async_contracts.py
+++ b/src/rosetta-mcp-server/tests/test_async_contracts.py
@@ -1,0 +1,35 @@
+import ast
+from pathlib import Path
+
+
+def test_async_handlers_do_not_call_sync_bundle():
+    # Async MCP handlers live in server.py and tools/*.py. Scan those production
+    # entry points to ensure none call synchronous bundle(), which would block
+    # the event loop during document downloads.
+    violations: list[str] = []
+
+    package_root = Path(__file__).resolve().parents[1] / "rosetta_mcp"
+    paths = [
+        package_root / "server.py",
+        *sorted((package_root / "tools").glob("*.py")),
+    ]
+
+    for path in paths:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.AsyncFunctionDef):
+                continue
+
+            for child in ast.walk(node):
+                if (
+                    isinstance(child, ast.Call)
+                    and isinstance(child.func, ast.Attribute)
+                    and child.func.attr == "bundle"
+                ):
+                    violations.append(
+                        f"{path}:{child.lineno} async function '{node.name}' calls synchronous .bundle()"
+                    )
+
+    assert not violations, "\n".join(violations)

--- a/src/rosetta-mcp-server/tests/test_bundler_and_query_builder.py
+++ b/src/rosetta-mcp-server/tests/test_bundler_and_query_builder.py
@@ -1,3 +1,8 @@
+import asyncio
+import time
+
+import pytest
+
 from rosetta_mcp.clients.document import DocumentClient
 from rosetta_mcp.services.bundler import Bundler
 from rosetta_mcp.services.query_builder import QueryBuilder
@@ -30,6 +35,48 @@ def test_bundler_sorts_and_wraps():
     assert xml.index('id="1"') < xml.index('id="2"')
     assert '<rosetta:file id="1" dataset="aia-r1" path="agents/a.md" name="a.md" tags="t1">' in xml
     assert '<rosetta:file id="2" dataset="aia-r1" path="rules/z.md" name="z.md" tags="t2">' in xml
+
+
+@pytest.mark.asyncio
+async def test_bundle_async_keeps_event_loop_live_while_download_blocks():
+    """Ensure blocking document downloads do not freeze the async event loop.
+
+    Run bundle_async() with a deliberately slow synchronous document download
+    alongside a fast coroutine. If the download is correctly offloaded, the
+    fast coroutine must complete before the blocking download finishes.
+    """
+    order: list[str] = []
+
+    class _SlowDocClient(DocumentClient):
+        def download_content(self, doc):
+            # Simulate a slow synchronous RAGFlow/network call.
+            time.sleep(0.6)
+            order.append("download_done")
+            return doc._content
+
+    async def _fast_task():
+        # This should still make progress while download_content() is blocked.
+        await asyncio.sleep(0.05)
+        order.append("fast_done")
+
+    bundler = Bundler(_SlowDocClient())
+
+    docs = [
+        _Doc("1", "a.md", "A", {"sort_order": 1, "tags": ["t1"], "resource_path": "agents/a.md"}),
+    ]
+
+    results = await asyncio.gather(
+        bundler.bundle_async(docs, "aia-r1"),
+        _fast_task(),
+    )
+    bundled_result = results[0]
+
+    # bundle_async() should still return the expected bundled XML document string.
+    assert 'id="1"' in bundled_result
+
+    # If download_content() ran directly on the event-loop thread,
+    # the fast coroutine could not finish until after the download.
+    assert order.index("fast_done") < order.index("download_done")
 
 
 def test_listing_uses_frontmatter_attr_and_self_closing():


### PR DESCRIPTION
Closes #227

## Summary

- Add `Bundler.bundle_async()` for async MCP handlers so synchronous RAGFlow document downloads do not block the event loop.
- Offload each per-document `download_content()` call with the existing `offload()` helper:
  `await offload(self._documents.download_content, doc)`.
- Update the async `query_instructions()` and `read_instruction_resource()` paths to `await bundler.bundle_async(...)`.
- Keep the existing synchronous `bundle()` method alongside `bundle_async()` rather than converting `bundle()` itself to async.
  - `server.py` still contains a synchronous instruction-loading path `_load_mcp_server_instructions` that calls `bundle()` (currently not used/commented in the active server flow), so preserving the synchronous API avoids unnecessarily changing that path.
  - This also follows the existing sync/async pattern used by the document cache, where blocking I/O is offloaded for async callers while the synchronous API is preserved.
- Add `test_bundle_async_keeps_event_loop_live_while_download_blocks()`:
  - Simulates a slow synchronous document download with `time.sleep()`.
  - Runs a short coroutine alongside `bundle_async()`.
  - Verifies the short coroutine completes before the blocking download finishes, proving the event loop remains responsive.
- Add `test_async_contracts.py` with a regression/architecture test that scans `server.py` and `tools/*.py`, where the async MCP handlers live, and fails if an async function calls synchronous `.bundle()`.
  - This prevents a future handler from accidentally reintroducing the same event-loop blocking behavior.

## Testing

- Full `rosetta-mcp-server` test suite passes with `336 passed`.
- `src/validate-types.sh` passes type validation.
- Performed an end-to-end local integration test using:
  - RAGFlow `v0.25.1` running locally with Docker.
  - A real `aia-r3` dataset and published `dangerous-actions/SKILL.md` document.
  - Rosetta MCP over STDIO.
  - `query_instructions(tags=["dangerous-actions"])`.

## Assumptions

- Document downloads should remain sequential unless there is a separate requirement to parallelize them. This change addresses event-loop blocking without introducing concurrent RAGFlow requests.