### PR TITLE
fix(hooks): avoid quadratic git branch delete matching

### DIFF
--- a/src/hooks/src/hooks/dangerous-actions/patterns.ts
+++ b/src/hooks/src/hooks/dangerous-actions/patterns.ts
@@ -101,11 +101,16 @@ const GIT_FORCE_REFSPEC_LA = String.raw`(?=(?:\s+-\S+)*\s+(?!-)(?!['"]?\+)\S+(?:
 // Lookaheads stop at common shell command separators so a later command cannot
 // accidentally supply the missing force/delete flag for an earlier branch command.
 // Start local-command matching at a segment boundary and stop the prefix at its
-// first `git branch`. If that candidate has no delete/force pair, no later local
-// candidate in the same segment can have one because its remaining suffix is a
-// subset. This avoids rescanning the same suffix from every candidate.
+// first `git branch`. Both lookaheads below scan unbounded to the segment end, so
+// every later candidate's window is a suffix of the first candidate's window:
+// any delete/force pair visible later is visible from the first candidate too.
+// Bounding either lookahead would invalidate this optimization and risk false
+// negatives.
 const GIT_BRANCH_LOCAL = String.raw`\bgit[^\S\r\n]+branch\b`;
 const GIT_BRANCH_SEGMENT_PREFIX = String.raw`(?:^|[;&|\r\n])(?:(?!${GIT_BRANCH_LOCAL})[^;&|\r\n])*`;
+// CR/LF must remain segment boundaries. This RegExp has no `m` flag, so `^` only
+// matches the input start; without explicit line separators the prefix cannot
+// begin after a line boundary.
 // Preserve the prior `\s+` behavior when `git` and `branch` straddle CR/LF. Such
 // candidates necessarily cross a separator, so their lookahead windows stay bounded.
 const GIT_BRANCH_CROSS_LINE = String.raw`\bgit[^\S\r\n]*[\r\n]\s*branch\b`;

--- a/src/hooks/src/hooks/dangerous-actions/patterns.ts
+++ b/src/hooks/src/hooks/dangerous-actions/patterns.ts
@@ -100,7 +100,16 @@ const GIT_FORCE_REFSPEC_LA = String.raw`(?=(?:\s+-\S+)*\s+(?!-)(?!['"]?\+)\S+(?:
 // independent so ordinary `-d` / `--delete` remains outside this guardrail.
 // Lookaheads stop at common shell command separators so a later command cannot
 // accidentally supply the missing force/delete flag for an earlier branch command.
-const GIT_BRANCH = String.raw`\bgit\s+branch\b`;
+// Start local-command matching at a segment boundary and stop the prefix at its
+// first `git branch`. If that candidate has no delete/force pair, no later local
+// candidate in the same segment can have one because its remaining suffix is a
+// subset. This avoids rescanning the same suffix from every candidate.
+const GIT_BRANCH_LOCAL = String.raw`\bgit[^\S\r\n]+branch\b`;
+const GIT_BRANCH_SEGMENT_PREFIX = String.raw`(?:^|[;&|\r\n])(?:(?!${GIT_BRANCH_LOCAL})[^;&|\r\n])*`;
+// Preserve the prior `\s+` behavior when `git` and `branch` straddle CR/LF. Such
+// candidates necessarily cross a separator, so their lookahead windows stay bounded.
+const GIT_BRANCH_CROSS_LINE = String.raw`\bgit[^\S\r\n]*[\r\n]\s*branch\b`;
+const GIT_BRANCH = String.raw`(?:${GIT_BRANCH_SEGMENT_PREFIX}${GIT_BRANCH_LOCAL}|${GIT_BRANCH_CROSS_LINE})`;
 const GIT_BRANCH_DELETE_LA = String.raw`(?=[^;&|\r\n]*(?:\s--delete\b|\s-[a-zA-Z]*[dD][a-zA-Z]*\b))`;
 const GIT_BRANCH_FORCE_LA = String.raw`(?=[^;&|\r\n]*(?:\s--force\b|\s-[a-zA-Z]*[fD][a-zA-Z]*\b))`;
 

--- a/src/hooks/tests/git-branch-delete.test.ts
+++ b/src/hooks/tests/git-branch-delete.test.ts
@@ -1,3 +1,4 @@
+import { performance } from 'node:perf_hooks';
 import { describe, expect, test } from 'vitest';
 import { DANGEROUS_BASH } from '../src/hooks/dangerous-actions/patterns';
 import { evaluateDangerous } from '../src/hooks/dangerous-actions/evaluate';
@@ -26,7 +27,22 @@ const forceDeleteVariants = [
   'git branch --force --delete throwaway-test',
   'git branch -d --force throwaway-test',
   'git branch --delete -f throwaway-test',
+  'git branch throwaway-test -d -f',
+  'git branch throwaway-test -f -d',
+  'git branch throwaway-test -D',
+  'git branch throwaway-test -df',
+  'git branch throwaway-test --delete --force',
+  'git branch -d throwaway-test -f',
+  'git branch --delete throwaway-test --force',
+  'git branch -qD throwaway-test',
+  'git branch -Dq throwaway-test',
+  'git branch -dfq throwaway-test',
+  'git branch -qfd throwaway-test',
+  'git\tbranch\t-d\t-f\tthrowaway-test',
+  'sudo git branch -D throwaway-test',
 ] as const;
+
+const commandSeparators = [';', '&&', '|', '\n', '\r\n'] as const;
 
 describe('git-branch-delete dangerous-action guard', () => {
   for (const command of forceDeleteVariants) {
@@ -48,21 +64,71 @@ describe('git-branch-delete dangerous-action guard', () => {
   }
 
   test.each([
+    'git branch',
+    'git branch new-feature',
     'git branch -d throwaway-test',
     'git branch --delete throwaway-test',
     'git branch -f throwaway-test',
     'git branch --force throwaway-test',
     'git branch --list',
     'git branch --show-current',
+    'git status --short',
+    'git switch throwaway-test',
+    'echo safe',
   ])('%s stays outside the force-delete guard', (command) => {
     expect(branchDelete.test(command)).toBe(false);
+    expect(evaluateDangerous(bashCtx(command))).toBeNull();
   });
 
-  test('a later shell command cannot supply the missing force flag', () => {
-    expect(branchDelete.test('git branch -d throwaway-test && echo --force')).toBe(false);
+  test('widely separated delete and force flags still match', () => {
+    const command = `git branch -d throwaway-test ${'branch-operand '.repeat(5_000)}-f`;
+    expect(branchDelete.test(command)).toBe(true);
+    expect(evaluateDangerous(bashCtx(command))?.kind).toBe('deny');
   });
 
-  test('a later shell command cannot supply the missing delete flag', () => {
-    expect(branchDelete.test('git branch -f throwaway-test; echo --delete')).toBe(false);
+  for (const separator of commandSeparators) {
+    test(`a dangerous command before ${JSON.stringify(separator)} is reconsidered`, () => {
+      expect(
+        evaluateDangerous(bashCtx(`git branch -D throwaway-test${separator}echo safe`))?.kind,
+      ).toBe('deny');
+    });
+
+    test(`a dangerous command after ${JSON.stringify(separator)} is reconsidered`, () => {
+      expect(
+        evaluateDangerous(bashCtx(`echo safe${separator}git branch -D throwaway-test`))?.kind,
+      ).toBe('deny');
+    });
+
+    test(`delete and force flags cannot combine across ${JSON.stringify(separator)}`, () => {
+      const command = `git branch -d first${separator}git branch -f second`;
+      expect(branchDelete.test(command)).toBe(false);
+      expect(evaluateDangerous(bashCtx(command))).toBeNull();
+    });
+
+    test(`a later command after ${JSON.stringify(separator)} cannot supply a force flag`, () => {
+      const command = `git branch -d throwaway-test${separator}echo --force`;
+      expect(branchDelete.test(command)).toBe(false);
+      expect(evaluateDangerous(bashCtx(command))).toBeNull();
+    });
+
+    test(`a later command after ${JSON.stringify(separator)} cannot supply a delete flag`, () => {
+      const command = `git branch -f throwaway-test${separator}echo --delete`;
+      expect(branchDelete.test(command)).toBe(false);
+      expect(evaluateDangerous(bashCtx(command))).toBeNull();
+    });
+  }
+
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx('git branch --list'));
+    }
+
+    const command = 'git branch -a '.repeat(8_000);
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(250);
   });
 });

--- a/src/hooks/tests/git-branch-delete.test.ts
+++ b/src/hooks/tests/git-branch-delete.test.ts
@@ -44,6 +44,13 @@ const forceDeleteVariants = [
 
 const commandSeparators = [';', '&&', '|', '\n', '\r\n'] as const;
 
+const crossLineForceDeleteVariants = [
+  ['LF', 'git\nbranch -D x'],
+  ['CRLF', 'git\r\nbranch -D x'],
+  ['CR', 'git\rbranch -D x'],
+  ['surrounding spaces and LF', 'git \n branch -d -f x'],
+] as const;
+
 describe('git-branch-delete dangerous-action guard', () => {
   for (const command of forceDeleteVariants) {
     test(`${command} matches the guard`, () => {
@@ -84,6 +91,29 @@ describe('git-branch-delete dangerous-action guard', () => {
     const command = `git branch -d throwaway-test ${'branch-operand '.repeat(5_000)}-f`;
     expect(branchDelete.test(command)).toBe(true);
     expect(evaluateDangerous(bashCtx(command))?.kind).toBe('deny');
+  });
+
+  // Each command puts CR/LF between `git` and `branch`, which the line-local
+  // alternative excludes, so these cases pin the dedicated cross-line path.
+  for (const [lineBreak, command] of crossLineForceDeleteVariants) {
+    test(`${lineBreak} between git and branch preserves force-delete detection`, () => {
+      expect(branchDelete.test(command)).toBe(true);
+      const result = evaluateDangerous(bashCtx(command));
+      expect(result?.kind).toBe('deny');
+      expect((result as { kind: 'deny'; reason: string }).reason).toContain(
+        '[git-branch-delete]',
+      );
+    });
+  }
+
+  test('a later dangerous git branch candidate in the same segment is reconsidered', () => {
+    const command = 'git branch -a git branch -D x';
+    expect(branchDelete.test(command)).toBe(true);
+    const result = evaluateDangerous(bashCtx(command));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain(
+      '[git-branch-delete]',
+    );
   });
 
   for (const separator of commandSeparators) {


### PR DESCRIPTION
## Summary

Remove repeated suffix rescanning from the `git-branch-delete` PreToolUse detector while preserving the force-delete coverage added by #299.

## Root cause

The previous matcher began at every `git branch` candidate and used two independent lookaheads: one for a delete flag and one for a force flag. Each lookahead scanned forward to the next `;`, `&`, `|`, CR/LF, or end of input.

On a separator-free command containing many candidates, unsuccessful matches therefore rescanned overlapping suffixes. Doubling the candidate count produced approximately four times the evaluation time.

## Structural solution

The matcher now starts local candidate discovery at each separator-bounded segment boundary and stops the prefix at the first line-local `git branch` candidate.

This is sufficient because every later candidate in that segment has a post-`branch` lookahead window that is a suffix of the first candidate's window. The existing delete and force predicates are unchanged existential checks, so any qualifying flag pair visible to a later candidate is also visible to the first.

A separate alternative preserves the previous `git\s+branch` behavior when the whitespace between `git` and `branch` crosses CR/LF. Those candidates cross a recognized boundary, so this legacy alternative does not recreate repeated scanning of one separator-free suffix. No arbitrary scan-distance bound or shell parser was introduced.

## Security behavior

The dangerous-command behavior introduced by #299 is preserved, including:

- `-d -f` and `-f -d`
- `-D`, `-fd`, and `-df`
- long, short, mixed, clustered, and reordered flags
- flags before, after, and around branch operands
- widely separated delete and force flags
- wrapper and whitespace variants
- `;`, `&&`, `|`, LF, and CRLF boundaries
- review-marker behavior

The delete and force lookaheads and separator set are unchanged. Flags from different command segments still cannot combine.

An independently compiled pre-change matcher at `70d401ec6d556005c16182024edfcfad3aa588ca` and the optimized matcher at `c0d6520ae21e054bd438389432b1f258fde8da40` (unchanged by follow-up commit `55d497009a726c198671106ab54b7d25b8321029`) produced zero differences across 12 explicit cases plus 3,000,000 deterministically generated token sequences (seed `0x313299`). The harness also asserts that the baseline source equals the recorded old matcher and that the baseline and final regex sources differ.

Separately, 20 ordering and clustering variants were exercised against Git 2.55.0 using an unmerged disposable branch. Git accepted every form and deleted the branch in every case.

## Performance impact

Local Linux Node 24 medians after warmup through the production `evaluateDangerous` path:

| Separator-free input | Before | After |
|---|---:|---:|
| 14 KB / 1,000 candidates | 27.51 ms | 0.20 ms |
| 28 KB / 2,000 candidates | 105.46 ms | 0.41 ms |
| 56 KB / 4,000 candidates | 419.91 ms | 0.81 ms |
| 112 KB / 8,000 candidates | 1,689.46 ms | 1.59 ms |

The fixed series grows approximately with input size and no longer exhibits the prior repeated-suffix rescan trend.

The regression test uses a 250 ms threshold for the 112 KB production-path workload. In a dedicated threshold run, the vulnerable minimum was 1,678.81 ms while the fixed maximum was 4.19 ms, leaving substantial headroom for CI variance.

## Tests

- Expanded dangerous flag-order, clustering, mixed-form, and wrapper coverage.
- Added flags-after-operands and widely separated flag cases.
- Added safe listing, creation, and unrelated-command cases.
- Added segment-isolation checks for every supported separator.
- Added cross-line CR/LF coverage for all four requested legacy whitespace forms.
- Added the same-segment later-candidate regression case.
- Added production-path performance regression coverage.
- Dedicated detector file: 109 tests passed.
- Full hooks suite: 1,257 tests passed.

## Validation

- `npm ci` — passed.
- `npm run check` — TypeScript validation passed.
- `npm run test` — passed; 45 hook bundles built, 34/34 test files passed, and 1,257/1,257 tests passed.
- Repository Python type validation — mypy passed across 55 source files.
- Repository Python suites — 339 MCP tests and 56 CLI tests passed.
- Repository pre-commit entrypoint — passed in an isolated LF WSL worktree, including both plugin generations, hooks type validation, 45-bundle build, and the full hooks suite.
- Performance threshold — 20/20 production-path runs on the 112 KB workload passed at 1.631–1.869 ms against the unchanged 250 ms limit.
- Mutation sanity checks — disabling the cross-line alternative dropped all four requested cases; bounding the lookaheads before the next local candidate dropped the same-segment case while a single dangerous candidate still matched.
- `npm audit --omit=dev` — 0 vulnerabilities.
- `git diff --check` — passed.
- DCO trailers — verified on both commits.

## Risk / blast radius

This modifies a PreToolUse dangerous-action security detector. A false negative could permit an unreviewed destructive branch deletion, while a pathological matcher can delay every Bash tool call.

Risk was controlled by retaining the existing flag predicates and separators, expanding the #299 regression matrix, comparing independently compiled pre-change and final matchers, validating supported forms against real Git, and exercising adversarial production-path inputs. The production change is confined to the `git-branch-delete` pattern.

## Compatibility

No dangerous-action behavior change is intended. Existing lexical separator handling, cross-line whitespace behavior, review-marker policy, evaluation interfaces, and module responsibilities are unchanged. Because this is a local matcher implementation change rather than an architecture change, no architecture documentation update is required.

## Limitations

- Native Windows cannot run the hooks package's Unix shell steps, so the repository pre-commit entrypoint was run in an isolated LF WSL worktree; it passed. Python validation ran separately because that worktree lacked a provisioned root venv.
- CodeQL is unavailable locally and remains a remote PR check.
- Performance values are local medians, not guarantees for every CI runner.

Fixes #313
