### PR TITLE
test(cli): cover dataset name resolution branches

### DIFF
--- a/src/rosetta-cli/tests/test_dataset_service.py
+++ b/src/rosetta-cli/tests/test_dataset_service.py
@@ -1,12 +1,15 @@
 from types import SimpleNamespace
 
+from rosetta_cli.rosetta_config import RosettaConfig
 from rosetta_cli.services.dataset_service import DatasetService
 
 
-def _config() -> SimpleNamespace:
-    return SimpleNamespace(
-        dataset_template="aia-{release}",
+def _config() -> RosettaConfig:
+    return RosettaConfig(
+        base_url="https://example.invalid",
+        api_key="ragflow-test",
         dataset_default="aia-default",
+        dataset_template="aia-{release}",
         page_size=1000,
     )
 
@@ -30,7 +33,7 @@ def test_resolve_dataset_name_uses_explicit_name_without_listing() -> None:
 
 
 def test_resolve_dataset_name_auto_detects_single_prefix_match(capsys) -> None:
-    client = _client("other", "aia-1.0")
+    client = _client("legacy-aia-1.0", "aia-1.0")
     service = DatasetService(client, _config())
 
     assert service.resolve_dataset_name(None) == ("aia-1.0", True)

--- a/src/rosetta-cli/tests/test_dataset_service.py
+++ b/src/rosetta-cli/tests/test_dataset_service.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+from rosetta_cli.services.dataset_service import DatasetService
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        dataset_template="aia-{release}",
+        dataset_default="aia-default",
+        page_size=1000,
+    )
+
+
+def _client(*dataset_names: str) -> SimpleNamespace:
+    calls: list[int] = []
+
+    def list_datasets(*, page_size: int):
+        calls.append(page_size)
+        return [SimpleNamespace(name=name) for name in dataset_names]
+
+    return SimpleNamespace(list_datasets=list_datasets, calls=calls)
+
+
+def test_resolve_dataset_name_uses_explicit_name_without_listing() -> None:
+    client = _client("aia-1.0")
+    service = DatasetService(client, _config())
+
+    assert service.resolve_dataset_name("chosen") == ("chosen", False)
+    assert client.calls == []
+
+
+def test_resolve_dataset_name_auto_detects_single_prefix_match(capsys) -> None:
+    client = _client("other", "aia-1.0")
+    service = DatasetService(client, _config())
+
+    assert service.resolve_dataset_name(None) == ("aia-1.0", True)
+    assert client.calls == [1000]
+    assert "Auto-detected dataset: aia-1.0" in capsys.readouterr().out
+
+
+def test_resolve_dataset_name_rejects_ambiguous_prefix_matches(capsys) -> None:
+    client = _client("aia-1.0", "unrelated", "aia-2.0")
+    service = DatasetService(client, _config())
+
+    assert service.resolve_dataset_name(None) == (None, False)
+    assert client.calls == [1000]
+
+    output = capsys.readouterr().out
+    assert "Multiple datasets match pattern 'aia-*':" in output
+    assert "  - aia-1.0" in output
+    assert "  - aia-2.0" in output
+    assert "Please specify which dataset using --dataset flag" in output
+
+
+def test_resolve_dataset_name_falls_back_when_prefix_has_no_matches(capsys) -> None:
+    client = _client("other", "different")
+    service = DatasetService(client, _config())
+
+    assert service.resolve_dataset_name(None) == ("aia-default", True)
+    assert client.calls == [1000]
+    assert "Using default dataset: aia-default" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
Add direct unit coverage for DatasetService.resolve_dataset_name instead of relying only on command tests that monkeypatch the method away.

The new focused test module covers all four resolution outcomes described in #259:
- explicit --dataset short-circuits without listing datasets;
- exactly one template-prefix match is auto-detected;
- multiple prefix matches return (None, False) and surface the choices;
- zero prefix matches fall back to dataset_default with auto_detected=True.

The fake client also records page_size calls so the tests exercise the production list path without requiring RAGFlow/network access.

No production behavior is changed.

Fixes #259

AI assistance was used to inspect the existing branch logic and prepare the focused regression coverage. I reviewed and take responsibility for the submitted tests.
