### PR TITLE
fix: batch of twelve low-risk fixes across mcp-server, cli, generator, hooks, and CI

### DIFF
--- a/.github/workflows/ci-rosetta-mcp.yml
+++ b/.github/workflows/ci-rosetta-mcp.yml
@@ -69,6 +69,21 @@ jobs:
       run: |
         twine check dist/*
 
+    - name: Assert chart appVersion matches rosetta-mcp-server version
+      run: |
+        set -euo pipefail
+        CHART_PATH=./src/helm-charts/rosetta-mcp-server
+        SERVER_PYPROJECT=./src/rosetta-mcp-server/pyproject.toml
+        APP_VERSION="$(grep -E '^appVersion:' "${CHART_PATH}/Chart.yaml" | awk '{print $2}' | tr -d '"')"
+        SERVER_VERSION="$(grep -E '^version = ' "${SERVER_PYPROJECT}" | head -1 | sed 's/version = "\(.*\)"/\1/')"
+        echo "Chart appVersion:           ${APP_VERSION}"
+        echo "rosetta-mcp-server version: ${SERVER_VERSION}"
+        if [ "${APP_VERSION}" != "${SERVER_VERSION}" ]; then
+          echo "::error::Chart.yaml appVersion (${APP_VERSION}) does not match src/rosetta-mcp-server/pyproject.toml version (${SERVER_VERSION}). values.yaml defaults image.tag to .Chart.AppVersion, so a default install would pull the wrong image. Bump Chart.yaml appVersion (and the chart version) - scripts/bump_versions.sh does both."
+          exit 1
+        fi
+        echo "appVersion is in sync."
+
     - name: Run tests
       working-directory: ./src/rosetta-mcp-server
       run: |

--- a/.github/workflows/publish-ims-mcp.yml
+++ b/.github/workflows/publish-ims-mcp.yml
@@ -17,6 +17,10 @@ jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
 
+    # Least privilege: no step consumes GITHUB_TOKEN; PyPI auth uses a password secret.
+    permissions:
+      contents: read
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v5

--- a/.github/workflows/publish-mcp-helm-chart.yml
+++ b/.github/workflows/publish-mcp-helm-chart.yml
@@ -36,6 +36,21 @@ jobs:
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 0.6.3
 
+      - name: Assert chart appVersion matches rosetta-mcp-server version
+        run: |
+          set -euo pipefail
+          CHART_PATH=./src/helm-charts/rosetta-mcp-server
+          SERVER_PYPROJECT=./src/rosetta-mcp-server/pyproject.toml
+          APP_VERSION="$(grep -E '^appVersion:' "${CHART_PATH}/Chart.yaml" | awk '{print $2}' | tr -d '"')"
+          SERVER_VERSION="$(grep -E '^version = ' "${SERVER_PYPROJECT}" | head -1 | sed 's/version = "\(.*\)"/\1/')"
+          echo "Chart appVersion:           ${APP_VERSION}"
+          echo "rosetta-mcp-server version: ${SERVER_VERSION}"
+          if [ "${APP_VERSION}" != "${SERVER_VERSION}" ]; then
+            echo "::error::Chart.yaml appVersion (${APP_VERSION}) does not match src/rosetta-mcp-server/pyproject.toml version (${SERVER_VERSION}). values.yaml defaults image.tag to .Chart.AppVersion, so a default install would pull the wrong image. Bump Chart.yaml appVersion (and the chart version) - scripts/bump_versions.sh does both."
+            exit 1
+          fi
+          echo "appVersion is in sync."
+
       - name: Lint, template, and unit test chart
         run: |
           CHART_PATH=./src/helm-charts/rosetta-mcp-server

--- a/.github/workflows/publish-rosetta-cli.yml
+++ b/.github/workflows/publish-rosetta-cli.yml
@@ -18,6 +18,10 @@ jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
 
+    # Least privilege: no step consumes GITHUB_TOKEN; PyPI auth uses a password secret.
+    permissions:
+      contents: read
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v5

--- a/.github/workflows/publish-rosetta-mcp.yml
+++ b/.github/workflows/publish-rosetta-mcp.yml
@@ -18,6 +18,10 @@ jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
 
+    # Least privilege: no step consumes GITHUB_TOKEN; PyPI auth uses a password secret.
+    permissions:
+      contents: read
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v5

--- a/docs/MCP-ARCHITECTURE.md
+++ b/docs/MCP-ARCHITECTURE.md
@@ -204,8 +204,8 @@ All three modes issue FastMCP JWTs to MCP clients and store upstream tokens in R
 
 **Key details:**
 - Version tracked in `rosetta:redis-schema-version` (plain integer)
-- Distributed lock (`rosetta:migration-lock`, 60 s TTL) prevents concurrent runs across pods on rolling deploys
-- Each migration runs exactly once; safe to deploy to multiple replicas simultaneously
+- Distributed lock (`rosetta:migration-lock`, 60 s TTL) deduplicates runs across pods on rolling deploys. Best-effort, not a guarantee: the TTL is never extended, so a run that outlives it loses the lock while still working. Release is fenced by a per-run token, so a run that lost the lock cannot delete another pod's fresh one
+- What actually makes multi-replica deploys safe is that every migration is idempotent and the version is re-read under the lock before any migration runs — not the lock itself. A migration may therefore run more than once
 - All migration activity logged at `INFO` level under `rosetta_mcp.migrations`
 
 **Current migrations:**
@@ -215,7 +215,7 @@ All three modes issue FastMCP JWTs to MCP clients and store upstream tokens in R
 | 1 | Baseline no-op — marks pre-migration deployments as version 1 |
 | 2 | Flushes `mcp-oauth-proxy-clients:*` keys so DCR/CIMD clients re-register with correct `required_scopes` |
 
-**Adding a migration:** add `_migrate_to_N`, bump `LATEST_REDIS_SCHEMA_VERSION = N`, deploy.
+**Adding a migration:** add `_migrate_to_N`, bump `LATEST_REDIS_SCHEMA_VERSION = N`, deploy. Every `_migrate_to_N` MUST be idempotent — the lock cannot guarantee a single execution, so re-running a migration must be harmless.
 
 ## VFS and Tags
 

--- a/docs/web/docs/mcp-architecture.md
+++ b/docs/web/docs/mcp-architecture.md
@@ -207,8 +207,8 @@ All three modes issue FastMCP JWTs to MCP clients and store upstream tokens in R
 
 **Key details:**
 - Version tracked in `rosetta:redis-schema-version` (plain integer)
-- Distributed lock (`rosetta:migration-lock`, 60 s TTL) prevents concurrent runs across pods on rolling deploys
-- Each migration runs exactly once; safe to deploy to multiple replicas simultaneously
+- Distributed lock (`rosetta:migration-lock`, 60 s TTL) deduplicates runs across pods on rolling deploys. Best-effort, not a guarantee: the TTL is never extended, so a run that outlives it loses the lock while still working. Release is fenced by a per-run token, so a run that lost the lock cannot delete another pod's fresh one
+- What actually makes multi-replica deploys safe is that every migration is idempotent and the version is re-read under the lock before any migration runs — not the lock itself. A migration may therefore run more than once
 - All migration activity logged at `INFO` level under `rosetta_mcp.migrations`
 
 **Current migrations:**

--- a/instructions/r3/core/agents/architect.md
+++ b/instructions/r3/core/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: "Architect solution, transform intent into reliable tech specs, etc. Full subagent."
 mode: subagent
-model: claude-5-opus-high, gpt-5.6-sol-high, gemini-3.7-flash-high
+model: claude-opus-5, gpt-5.6-sol-high, gemini-3.7-flash-high
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/architect~profile-lightweight-only~overwrite~.md
+++ b/instructions/r3/core/agents/architect~profile-lightweight-only~overwrite~.md
@@ -2,7 +2,7 @@
 name: architect
 description: "Architect solution, transform intent into reliable tech specs, etc. Full subagent."
 mode: subagent
-model: gpt-5.6-sol-high, claude-5-opus-high, grok-4.6-high, gemini-3.7-flash-high
+model: gpt-5.6-sol-high, claude-opus-5, grok-4.6-high, gemini-3.7-flash-high
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/discoverer.md
+++ b/instructions/r3/core/agents/discoverer.md
@@ -2,7 +2,7 @@
 name: discoverer
 description: "Discover project context, patterns, affected areas, dependencies, etc. Lightweight subagent."
 mode: subagent
-model: claude-5-sonnet, gpt-5.6-terra-medium, gemini-3.7-flash-high, grok-4.6
+model: claude-sonnet-5, gpt-5.6-terra-medium, gemini-3.7-flash-high, grok-4.6
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/discoverer~profile-lightweight-only~overwrite~.md
+++ b/instructions/r3/core/agents/discoverer~profile-lightweight-only~overwrite~.md
@@ -2,7 +2,7 @@
 name: discoverer
 description: "Discover project context, patterns, affected areas, dependencies, etc. Lightweight subagent."
 mode: subagent
-model: gpt-5.6-luna-high, claude-4.5-haiku, gemini-3.7-flash-low, grok-4.6-low
+model: gpt-5.6-luna-high, claude-haiku-4-5, gemini-3.7-flash-low, grok-4.6-low
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/engineer.md
+++ b/instructions/r3/core/agents/engineer.md
@@ -2,7 +2,7 @@
 name: engineer
 description: "Implement and test to high quality under the orchestrator-assigned identity. Full subagent."
 mode: subagent
-model: claude-5-sonnet, gpt-5.6-terra-medium, gemini-3.7-flash-low, grok-4.6
+model: claude-sonnet-5, gpt-5.6-terra-medium, gemini-3.7-flash-low, grok-4.6
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/engineer~profile-lightweight-only~overwrite~.md
+++ b/instructions/r3/core/agents/engineer~profile-lightweight-only~overwrite~.md
@@ -2,7 +2,7 @@
 name: engineer
 description: "Implement and test to high quality under the orchestrator-assigned identity. Full subagent."
 mode: subagent
-model: gpt-5.6-luna-xhigh, gpt-5.6-terra-high, claude-5-sonnet, gemini-3.7-flash-medium, grok-4.6-medium, composer-2.5
+model: gpt-5.6-luna-xhigh, gpt-5.6-terra-high, claude-sonnet-5, gemini-3.7-flash-medium, grok-4.6-medium, composer-2.5
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/executor.md
+++ b/instructions/r3/core/agents/executor.md
@@ -2,7 +2,7 @@
 name: executor
 description: "Run simple commands, collect and summarize results to protect parent context. Lightweight subagent."
 mode: subagent
-model: claude-4.5-haiku, gpt-5.6-terra-low, gemini-3.7-flash-low, composer-2.5, gpt-5.6-luna
+model: claude-haiku-4-5, gpt-5.6-terra-low, gemini-3.7-flash-low, composer-2.5, gpt-5.6-luna
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/executor~profile-lightweight-only~overwrite~.md
+++ b/instructions/r3/core/agents/executor~profile-lightweight-only~overwrite~.md
@@ -2,7 +2,7 @@
 name: executor
 description: "Run simple commands, collect and summarize results to protect parent context. Lightweight subagent."
 mode: subagent
-model: gpt-5.6-luna-medium, claude-4.5-haiku, gemini-3.7-flash-low, grok-4.6-low, composer-2.5
+model: gpt-5.6-luna-medium, claude-haiku-4-5, gemini-3.7-flash-low, grok-4.6-low, composer-2.5
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/planner.md
+++ b/instructions/r3/core/agents/planner.md
@@ -2,7 +2,7 @@
 name: planner
 description: "Plan execution: turn approved intent/specs into a sequenced plan scaled to size. Full subagent."
 mode: subagent
-model: claude-5-opus-high, gpt-5.6-sol-high, gemini-3.7-flash-high
+model: claude-opus-5, gpt-5.6-sol-high, gemini-3.7-flash-high
 readonly: false
 tags: ["subagent", "agent", "planning"]
 baseSchema: docs/schemas/agent.md

--- a/instructions/r3/core/agents/planner~profile-lightweight-only~overwrite~.md
+++ b/instructions/r3/core/agents/planner~profile-lightweight-only~overwrite~.md
@@ -2,7 +2,7 @@
 name: planner
 description: "Plan execution: turn approved intent/specs into a sequenced plan scaled to size. Full subagent."
 mode: subagent
-model: gpt-5.6-sol-high, claude-5-opus-high, grok-4.6-high, gemini-3.7-flash-high
+model: gpt-5.6-sol-high, claude-opus-5, grok-4.6-high, gemini-3.7-flash-high
 readonly: false
 tags: ["subagent", "agent", "planning"]
 baseSchema: docs/schemas/agent.md

--- a/instructions/r3/core/agents/prompt-engineer.md
+++ b/instructions/r3/core/agents/prompt-engineer.md
@@ -2,7 +2,7 @@
 name: prompt-engineer
 description: "Author and adapt prompts — discover, draft, deliver — under HITL approvals. Full subagent."
 mode: subagent
-model: claude-5-opus-high, gpt-5.6-sol-high, gemini-3.7-flash-high
+model: claude-opus-5, gpt-5.6-sol-high, gemini-3.7-flash-high
 readonly: false
 tags: ["subagent", "agent"]
 baseSchema: docs/schemas/agent.md

--- a/instructions/r3/core/agents/prompt-engineer~profile-lightweight-only~overwrite~.md
+++ b/instructions/r3/core/agents/prompt-engineer~profile-lightweight-only~overwrite~.md
@@ -2,7 +2,7 @@
 name: prompt-engineer
 description: "Author and adapt prompts — discover, draft, deliver — under HITL approvals. Full subagent."
 mode: subagent
-model: gpt-5.6-sol-high, claude-5-opus-high, grok-4.6-high, gemini-3.7-flash-high
+model: gpt-5.6-sol-high, claude-opus-5, grok-4.6-high, gemini-3.7-flash-high
 readonly: false
 tags: ["subagent", "agent"]
 baseSchema: docs/schemas/agent.md

--- a/instructions/r3/core/agents/requirements-engineer.md
+++ b/instructions/r3/core/agents/requirements-engineer.md
@@ -2,7 +2,7 @@
 name: requirements-engineer
 description: "Author, refine, and finalize requirements and specifications with traceability. Full subagent."
 mode: subagent
-model: claude-5-opus-high, gpt-5.6-sol-high, gemini-3.7-flash-high
+model: claude-opus-5, gpt-5.6-sol-high, gemini-3.7-flash-high
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/requirements-engineer~profile-lightweight-only~overwrite~.md
+++ b/instructions/r3/core/agents/requirements-engineer~profile-lightweight-only~overwrite~.md
@@ -2,7 +2,7 @@
 name: requirements-engineer
 description: "Author, refine, and finalize requirements and specifications with traceability. Full subagent."
 mode: subagent
-model: gpt-5.6-sol-high, claude-5-opus-high, grok-4.6-high, gemini-3.7-flash-high
+model: gpt-5.6-sol-high, claude-opus-5, grok-4.6-high, gemini-3.7-flash-high
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/researcher.md
+++ b/instructions/r3/core/agents/researcher.md
@@ -2,7 +2,7 @@
 name: researcher
 description: "Run deep research with grounded references, systematic exploration, self-validation, etc. Full subagent."
 mode: subagent
-model: claude-5-sonnet, gpt-5.6-terra-medium, gemini-3.7-flash-high, grok-4.6
+model: claude-sonnet-5, gpt-5.6-terra-medium, gemini-3.7-flash-high, grok-4.6
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/researcher~profile-lightweight-only~overwrite~.md
+++ b/instructions/r3/core/agents/researcher~profile-lightweight-only~overwrite~.md
@@ -2,7 +2,7 @@
 name: researcher
 description: "Run deep research with grounded references, systematic exploration, self-validation, etc. Full subagent."
 mode: subagent
-model: gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-5-sonnet, composer-2.5
+model: gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-sonnet-5, composer-2.5
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/reviewer.md
+++ b/instructions/r3/core/agents/reviewer.md
@@ -2,7 +2,7 @@
 name: reviewer
 description: "Review artifacts against intent and contracts, recommend, etc. Full subagent."
 mode: subagent
-model: gpt-5.6-terra-medium, gemini-3.7-flash-high, claude-5-sonnet, grok-4.6
+model: gpt-5.6-terra-medium, gemini-3.7-flash-high, claude-sonnet-5, grok-4.6
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/reviewer~profile-lightweight-only~overwrite~.md
+++ b/instructions/r3/core/agents/reviewer~profile-lightweight-only~overwrite~.md
@@ -2,7 +2,7 @@
 name: reviewer
 description: "Review artifacts against intent and contracts, recommend, etc. Full subagent."
 mode: subagent
-model: gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-5-sonnet, composer-2.5
+model: gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-sonnet-5, composer-2.5
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/validator.md
+++ b/instructions/r3/core/agents/validator.md
@@ -2,7 +2,7 @@
 name: validator
 description: "Validate that implementation matches intent via execution and evidence. Full subagent."
 mode: subagent
-model: gpt-5.6-terra-medium, gemini-3.7-flash-high, claude-5-sonnet, grok-4.6
+model: gpt-5.6-terra-medium, gemini-3.7-flash-high, claude-sonnet-5, grok-4.6
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/agents/validator~profile-lightweight-only~overwrite~.md
+++ b/instructions/r3/core/agents/validator~profile-lightweight-only~overwrite~.md
@@ -2,7 +2,7 @@
 name: validator
 description: "Validate that implementation matches intent via execution and evidence. Full subagent."
 mode: subagent
-model: gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-5-sonnet, composer-2.5
+model: gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-sonnet-5, composer-2.5
 readonly: false
 baseSchema: docs/schemas/agent.md
 ---

--- a/instructions/r3/core/templates/shell-schemas/agent-shell.md
+++ b/instructions/r3/core/templates/shell-schemas/agent-shell.md
@@ -8,7 +8,7 @@ description: "[Brief description of WHEN and HOW to use this agent and WHAT it d
 mode: "[Defines agent type]"
 
 # Model Configuration (Optional)
-# model — [Specifies which LLM model to use, any thinking/reasoning must be done with stronger models and high reasoning efforts, while execution with cheaper] [string] [Cursor, OpenCode, Claude Code] [ex: claude-5-sonnet]
+# model — [Specifies which LLM model to use, any thinking/reasoning must be done with stronger models and high reasoning efforts, while execution with cheaper] [string] [Cursor, OpenCode, Claude Code] [ex: claude-sonnet-5]
 model: "[Specifies which LLM model to use, any thinking/reasoning must be done with stronger models and high reasoning efforts, while execution with cheaper]"
 # temperature — [Controls response randomness] [float] [OpenCode] [ex: 0.7]
 temperature: "[Controls response randomness]"

--- a/instructions/r3/core/templates/shell-schemas/skill-shell.md
+++ b/instructions/r3/core/templates/shell-schemas/skill-shell.md
@@ -22,7 +22,7 @@ argument-hint: "[Hint shown during autocomplete to indicate expected arguments]"
 # Tools & Model Configuration (Optional)
 # allowed-tools — [Tools Claude can use without asking permission when this skill is active, dangerous, only keep it when you know exactly] [string] [Claude Code] [ex: Bash(git diff:*)]
 allowed-tools: "[Tools Claude can use without asking permission when this skill is active, dangerous, only keep it when you know exactly]"
-# model — [Model to use when this skill is active] [string] [Claude Code] [ex: claude-5-sonnet]
+# model — [Model to use when this skill is active] [string] [Claude Code] [ex: claude-sonnet-5]
 model: "[Model to use when this skill is active]"
 
 # [Latest Models: Anthropic (claude-opus-5, claude-sonnet-5, claude-haiku-4-5), OpenAI (gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna), Google (gemini-3.7-flash), Cursor (grok-4.6, composer-2.5), Z.ai (glm-5).]

--- a/instructions/r3/core/workflows/coding-flow~profile-lightweight-only~overwrite~.md
+++ b/instructions/r3/core/workflows/coding-flow~profile-lightweight-only~overwrite~.md
@@ -35,7 +35,7 @@ Lightweight variant: a single architect pass produces discovery, design, specs, 
 
 </prerequisites>
 
-<solution_design phase="1" applies="ALL" subagent="architect" role="Architect producing discovery, design, specs, and plan in one pass" subagent_required_model="gpt-5.6-sol-high, claude-5-opus-high, grok-4.6-high, gemini-3.7-flash-high">
+<solution_design phase="1" applies="ALL" subagent="architect" role="Architect producing discovery, design, specs, and plan in one pass" subagent_required_model="gpt-5.6-sol-high, claude-opus-5, grok-4.6-high, gemini-3.7-flash-high">
 
 Execute strongly in the specified order. A step MUST NOT start before the previous step is complete.
 
@@ -53,7 +53,7 @@ Execute strongly in the specified order. A step MUST NOT start before the previo
 
 </solution_design>
 
-<review_plan phase="2" applies="MEDIUM,LARGE" subagent="reviewer" role="Reviewer inspecting architecture notes, specs, and plan against intent" subagent_required_model="gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-5-sonnet, composer-2.5" must-be-subagent>
+<review_plan phase="2" applies="MEDIUM,LARGE" subagent="reviewer" role="Reviewer inspecting architecture notes, specs, and plan against intent" subagent_required_model="gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-sonnet-5, composer-2.5" must-be-subagent>
 
 1. Review all three artifacts together - `architecture-notes.md`, specs, and plan - against user request, do not assume user is in context, give him full information with TLDR.
 2. Input: architecture notes, specs, plan, user request. Output: review findings and recommendations.
@@ -70,7 +70,7 @@ Execute strongly in the specified order. A step MUST NOT start before the previo
 
 </user_review_design>
 
-<implementation phase="4" applies="ALL" subagent="engineer" role="Senior engineer executing approved plan" subagent_required_model="gpt-5.6-luna-xhigh, gpt-5.6-terra-high, claude-5-sonnet, gemini-3.7-flash-medium, grok-4.6-medium, composer-2.5">
+<implementation phase="4" applies="ALL" subagent="engineer" role="Senior engineer executing approved plan" subagent_required_model="gpt-5.6-luna-xhigh, gpt-5.6-terra-high, claude-sonnet-5, gemini-3.7-flash-medium, grok-4.6-medium, composer-2.5">
 
 1. Implement approved plan. Build MUST succeed. Tests excluded.
 2. Input: approved specs + plan. Demand subagent to read and execute it fully. Do not repeat contents => reference instead. Output: working code, build passing, update relevant documentation briefly (CONTEXT.md, ARCHITECTURE.md, etc).
@@ -83,7 +83,7 @@ Execute strongly in the specified order. A step MUST NOT start before the previo
 
 </implementation>
 
-<review_code phase="5" applies="ALL" subagent="reviewer" role="Reviewer inspecting implementation against specs" subagent_required_model="gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-5-sonnet, composer-2.5" must-be-subagent>
+<review_code phase="5" applies="ALL" subagent="reviewer" role="Reviewer inspecting implementation against specs" subagent_required_model="gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-sonnet-5, composer-2.5" must-be-subagent>
 
 1. Review code changes against approved specs and plan.
 2. Input: implementation diff, specs, plan, check if documentation is updated, brief, and matches the file intent. Output: review findings and recommendations.
@@ -94,7 +94,7 @@ Execute strongly in the specified order. A step MUST NOT start before the previo
 
 </review_code>
 
-<tests phase="6" applies="ALL" subagent="engineer" role="Senior engineer writing and running tests" subagent_required_model="gpt-5.6-luna-xhigh, gpt-5.6-terra-high, claude-5-sonnet, gemini-3.7-flash-medium, grok-4.6-medium, composer-2.5">
+<tests phase="6" applies="ALL" subagent="engineer" role="Senior engineer writing and running tests" subagent_required_model="gpt-5.6-luna-xhigh, gpt-5.6-terra-high, claude-sonnet-5, gemini-3.7-flash-medium, grok-4.6-medium, composer-2.5">
 
 1. Write and execute tests. All MUST succeed, isolated, idempotent.
 2. Input: implementation, specs. Demand subagent to read specs fully. Do not repeat contents => reference instead. Output: passing tests with coverage.
@@ -104,7 +104,7 @@ Execute strongly in the specified order. A step MUST NOT start before the previo
 
 </tests>
 
-<review_tests phase="7" applies="MEDIUM,LARGE" subagent="reviewer" role="Reviewer inspecting test coverage and quality" subagent_required_model="gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-5-sonnet, composer-2.5" must-be-subagent>
+<review_tests phase="7" applies="MEDIUM,LARGE" subagent="reviewer" role="Reviewer inspecting test coverage and quality" subagent_required_model="gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-sonnet-5, composer-2.5" must-be-subagent>
 
 1. Review tests against specs: coverage, scenarios, edge cases, mocking correctness.
 2. Input: tests, specs, implementation. Output: review findings and recommendations.
@@ -114,7 +114,7 @@ Execute strongly in the specified order. A step MUST NOT start before the previo
 
 </review_tests>
 
-<final_validation phase="8" applies="MEDIUM,LARGE" subagent="validator" role="Final end-to-end verification" subagent_required_model="gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-5-sonnet, composer-2.5">
+<final_validation phase="8" applies="MEDIUM,LARGE" subagent="validator" role="Final end-to-end verification" subagent_required_model="gemini-3.7-flash-medium, grok-4.6-medium, gpt-5.6-terra-high, gpt-5.6-luna-xhigh, claude-sonnet-5, composer-2.5">
 
 1. Systematic by-dependency validation: databases, APIs, web, mobile. Check logs, clean up.
 2. Additionally systematic "manual QA" by yourself.

--- a/scripts/bump_versions.sh
+++ b/scripts/bump_versions.sh
@@ -22,6 +22,12 @@ get_json_version() {
     grep '"version"' "$1" | head -1 | sed 's/.*"version": "\(.*\)".*/\1/'
 }
 
+# get_yaml_top_version <file> <key> — reads a top-level `key: value` (quotes optional).
+# awk/tr rather than a sed group: BSD sed (macOS) has no `\?`.
+get_yaml_top_version() {
+    grep "^$2: " "$1" | head -1 | awk '{print $2}' | tr -d '"'
+}
+
 # bump_pre <version> [separator]
 # separator selects the target pre-release style, independent of the input:
 #   ""  -> PEP 440 (toml):        3.0.0b01
@@ -184,6 +190,8 @@ printf "  %-55s %s\n" "[package.json] src/rosettify/package.json" "$(get_json_ve
 printf "  %-55s %s\n" "[package.json] src/rosettify-plugins/package.json" "$(get_json_version "$ROOT/src/rosettify-plugins/package.json")"
 printf "  %-55s %s\n" "[package.json] src/rosettify-prompts/package.json" "$(get_json_version "$ROOT/src/rosettify-prompts/package.json")"
 printf "  %-55s %s\n" "[package.json] src/curiocity/package.json" "$(get_json_version "$ROOT/src/curiocity/package.json")"
+printf "  %-55s %s\n" "[chart]       src/helm-charts/rosetta-mcp-server/Chart.yaml" \
+    "$(get_yaml_top_version "$ROOT/src/helm-charts/rosetta-mcp-server/Chart.yaml" version) (appVersion $(get_yaml_top_version "$ROOT/src/helm-charts/rosetta-mcp-server/Chart.yaml" appVersion))"
 
 echo ""
 echo "Bump type:"
@@ -230,6 +238,28 @@ if ask_yn "Bump $rel  ($current → $new_version, rosetta-mcp → $ROSETTA_VERSI
     sedi "s/^version = \"${current}\"/version = \"${new_version}\"/" "$f"
     old_rosetta="$(grep 'rosetta-mcp==' "$f" | sed 's/.*rosetta-mcp==\([^"]*\)".*/\1/')"
     sedi "s/\"rosetta-mcp==${old_rosetta}\"/\"rosetta-mcp==${ROSETTA_VERSION}\"/" "$f"
+    echo -e "  ${GREEN}Updated${RESET}"
+else
+    echo "  Skipped"
+fi
+
+echo ""
+echo "--- src/helm-charts/rosetta-mcp-server/Chart.yaml ---"
+# Helm chart: bump chart `version` + sync `appVersion` to rosetta-mcp-server.
+# values.yaml leaves image.tag commented out and deployment.yaml defaults it to
+# .Chart.AppVersion, so appVersion MUST track the server version or a default
+# `helm install` pulls a stale image. The chart `version` must move in the same
+# commit: publish-mcp-helm-chart.yml pushes whatever `version:` says with no
+# version-exists guard, so reusing it overwrites the published chart in place.
+# Chart versions are SemVer 2, so pre-releases use the "-" separator (0.4.3-b00).
+f="$ROOT/src/helm-charts/rosetta-mcp-server/Chart.yaml"
+current="$(get_yaml_top_version "$f" version)"
+current_app="$(get_yaml_top_version "$f" appVersion)"
+rel="${f#$ROOT/}"
+new_version="$(compute_new_version "$current" "-")"
+if ask_yn "Bump $rel  ($current → $new_version, appVersion $current_app → $ROSETTA_VERSION)?" "n"; then
+    sedi "s/^version: ${current}$/version: ${new_version}/" "$f"
+    sedi "s/^appVersion: \"${current_app}\"$/appVersion: \"${ROSETTA_VERSION}\"/" "$f"
     echo -e "  ${GREEN}Updated${RESET}"
 else
     echo "  Skipped"

--- a/src/helm-charts/rosetta-mcp-server/Chart.yaml
+++ b/src/helm-charts/rosetta-mcp-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rosetta-mcp-helm-chart
 description: Helm chart for Rosetta MCP server - the consulting layer between IDEs and Rosetta knowledge base (RAGFlow)
 type: application
-version: 0.4.1
-appVersion: "2.0.25"
+version: 0.4.2
+appVersion: "3.0.4"
 keywords:
   - rosetta
   - mcp

--- a/src/helm-charts/rosetta-mcp-server/values-dev.example.yaml
+++ b/src/helm-charts/rosetta-mcp-server/values-dev.example.yaml
@@ -3,7 +3,7 @@
 # Replace placeholder hostnames and URLs with your dev environment values.
 
 image:
-  tag: "2.0.25"
+  tag: "3.0.4"
 
 ingress:
   host: rosetta-dev.example.com

--- a/src/helm-charts/rosetta-mcp-server/values-prod.example.yaml
+++ b/src/helm-charts/rosetta-mcp-server/values-prod.example.yaml
@@ -2,7 +2,7 @@
 # Use with: helm install -f values.yaml -f values-prod.yaml ...
 
 image:
-  tag: "2.0.25"
+  tag: "3.0.4"
 
 ingress:
   host: rosetta.example.com

--- a/src/hooks/src/runtime/types.ts
+++ b/src/hooks/src/runtime/types.ts
@@ -55,9 +55,9 @@ export type HookActivation = {
   fs?:        FsPredicate;
 };
 
-export type HookThrottle =
-  | { debounceMs: number }
-  | { dedupBy: readonly ('session' | 'filePath' | 'ide' | 'toolName' | 'toolInput')[] };
+export type HookThrottle = {
+  dedupBy: readonly ('session' | 'filePath' | 'ide' | 'toolName' | 'toolInput')[];
+};
 
 export interface HookDefinition {
   name:      string;

--- a/src/rosetta-cli/rosetta_cli/commands/cleanup_command.py
+++ b/src/rosetta-cli/rosetta_cli/commands/cleanup_command.py
@@ -87,7 +87,16 @@ class CleanupCommand(BaseCommand):
         dataset_service: DatasetService,
         args: CommandArgs,
     ) -> list[DocumentLike]:
-        """Get documents to delete based on filters."""
+        """Get documents to delete based on filters.
+
+        Accepted limitation: every branch below reads one page, bounded by
+        RAGFLOW_PAGE_SIZE (default 1000). On a dataset larger than that, this
+        command deletes the documents on the first page and reports success -
+        the remainder is left in place with no warning. The instruction set is
+        not expected to approach the cap, and this command serves the optional
+        MCP publishing pipeline rather than plugin delivery. Anyone pointing
+        `--dataset` at a larger dataset should know the delete is partial.
+        """
         document_service = DocumentService(self.client)
         
         if args.tags:

--- a/src/rosetta-cli/rosetta_cli/commands/parse_command.py
+++ b/src/rosetta-cli/rosetta_cli/commands/parse_command.py
@@ -11,7 +11,7 @@ from ..services.auth_service import AuthService
 
 
 from .base_command import BaseCommand
-from ..typing_utils import CommandArgs, DatasetLike, JsonDict
+from ..typing_utils import CommandArgs, DatasetLike, DocumentLike, JsonDict
 
 
 class ParseCommand(BaseCommand):
@@ -102,58 +102,53 @@ class ParseCommand(BaseCommand):
             traceback.print_exc()
             return 1
     
+    # RAGFlow `run` values that mean a document still needs parsing.
+    PARSE_REQUIRED_STATUSES = ("FAIL", "UNSTART", "CANCEL")
+
     def _get_documents_to_parse(self, dataset: DatasetLike, args: CommandArgs) -> tuple[list[JsonDict], dict[str, int]]:
         """Get documents that need parsing."""
-        document_service = DocumentService(self.client)
         docs_to_parse: list[JsonDict] = []
         status_counts = {'done': 0, 'running': 0}
         
         print(f"Checking parsing status for documents...")
         
+        # One unfiltered list call serves both modes: force selects everything,
+        # default partitions the same list client-side on `run`. Default mode used
+        # to make two calls - a server-side run= filter, plus a full list purely to
+        # tally done/running for the summary.
+        #
+        # Deliberate tradeoff, not a no-op: the server-filtered call surfaced up to
+        # page_size documents *needing parsing*, whereas page 1 of an unfiltered
+        # list surfaces only the needing-parse documents that happen to fall inside
+        # it. Once a dataset exceeds RAGFLOW_PAGE_SIZE this can therefore select
+        # fewer documents than before. Immaterial at current volumes (default
+        # page_size is 1000, against ~470 instruction files); revisit with real
+        # pagination if a dataset approaches the cap. The page-1-only truncation
+        # itself is pre-existing - it already applied to the force branch and to
+        # the done/running tally.
+        documents = dataset.list_documents(page_size=self.config.page_size)
+        
+        selected: list[tuple[DocumentLike, str]] = []
+        for document in documents:
+            status = self._count_parse_status(status_counts, document)
+            if args.force or status in self.PARSE_REQUIRED_STATUSES:
+                selected.append((document, status))
+        
         if args.force:
-            # Force mode: all documents
-            documents = dataset.list_documents(page_size=self.config.page_size)
-            
-            print(f"Found {len(documents)} document(s) (force mode - parsing all)\n")
-            
-            for document in documents:
-                status = self._count_parse_status(status_counts, document)
-                doc_id = getattr(document, 'id', None)
-                if doc_id:
-                    docs_to_parse.append({
-                        "id": doc_id,
-                        "name": getattr(document, 'name', 'Untitled'),
-                        "dataset_id": dataset.id,
-                        "folder": ".",
-                        "status": status
-                    })
+            print(f"Found {len(selected)} document(s) (force mode - parsing all)\n")
         else:
-            # Default mode: filter by status (need parsing)
-            documents_needing_parse = document_service.list_documents_by_status(
-                dataset,
-                statuses=["FAIL", "UNSTART", "CANCEL"],
-                limit=self.config.page_size
-            )
-
-            # Tally skipped documents from the full list so the summary reflects
-            # what this run will not re-trigger.
-            all_documents = dataset.list_documents(page_size=self.config.page_size)
-            for document in all_documents:
-                self._count_parse_status(status_counts, document)
-            
-            print(f"Found {len(documents_needing_parse)} document(s) needing parsing\n")
-            
-            for document in documents_needing_parse:
-                status = self._count_parse_status(status_counts, document)
-                doc_id = getattr(document, 'id', None)
-                if doc_id:
-                    docs_to_parse.append({
-                        "id": doc_id,
-                        "name": getattr(document, 'name', 'Untitled'),
-                        "dataset_id": dataset.id,
-                        "folder": ".",
-                        "status": status
-                    })
+            print(f"Found {len(selected)} document(s) needing parsing\n")
+        
+        for document, status in selected:
+            doc_id = getattr(document, 'id', None)
+            if doc_id:
+                docs_to_parse.append({
+                    "id": doc_id,
+                    "name": getattr(document, 'name', 'Untitled'),
+                    "dataset_id": dataset.id,
+                    "folder": ".",
+                    "status": status
+                })
         
         return docs_to_parse, status_counts
 

--- a/src/rosetta-cli/rosetta_cli/commands/parse_command.py
+++ b/src/rosetta-cli/rosetta_cli/commands/parse_command.py
@@ -121,11 +121,15 @@ class ParseCommand(BaseCommand):
         # page_size documents *needing parsing*, whereas page 1 of an unfiltered
         # list surfaces only the needing-parse documents that happen to fall inside
         # it. Once a dataset exceeds RAGFLOW_PAGE_SIZE this can therefore select
-        # fewer documents than before. Immaterial at current volumes (default
-        # page_size is 1000, against ~470 instruction files); revisit with real
-        # pagination if a dataset approaches the cap. The page-1-only truncation
-        # itself is pre-existing - it already applied to the force branch and to
-        # the done/running tally.
+        # fewer documents than before.
+        #
+        # Accepted limitation, not a deferred fix: every list path in this command
+        # reads page 1 only, bounded by RAGFLOW_PAGE_SIZE (default 1000). The
+        # instruction set is not expected to approach that cap - it is roughly 470
+        # files - and this command serves the optional MCP publishing pipeline,
+        # which is secondary to plugin delivery. The page-1-only read is also
+        # pre-existing: it already applied to the force branch and to the
+        # done/running tally.
         documents = dataset.list_documents(page_size=self.config.page_size)
         
         selected: list[tuple[DocumentLike, str]] = []

--- a/src/rosetta-cli/rosetta_cli/rosetta_config.py
+++ b/src/rosetta-cli/rosetta_cli/rosetta_config.py
@@ -9,7 +9,6 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from urllib.parse import urlparse
 
 from dotenv import load_dotenv
 
@@ -69,14 +68,40 @@ def find_env_file(env_name: str | None = None) -> Path | None:
     return None
 
 
-def _first_subdomain(url: str) -> str | None:
-    """Extract first subdomain from URL. 'https://ims-dev.example.com/' -> 'ims-dev'."""
-    try:
-        hostname = urlparse(url).hostname or ""
-        parts = hostname.split(".")
-        return parts[0] if len(parts) > 1 else None
-    except Exception:
-        return None
+# Environment keywords searched for in the RAGFlow URL, in scan order.
+#
+# ORDER IS LOAD-BEARING - do not sort or alphabetize this tuple. The scan takes the
+# first keyword that appears anywhere in the URL, so a keyword that contains another
+# keyword must be listed before the one it contains. "prod" is a substring of
+# "preprod" - the only such pair in this set - so putting "prod" first would make
+# preprod.example.com resolve to "prod". test_environment_keyword_order_is_safe in
+# tests/test_rosetta_config_environment.py enforces this invariant.
+ENVIRONMENT_KEYWORDS: tuple[str, ...] = (
+    "preprod",  # must precede "prod", which it contains
+    "prod",
+    "stag",
+    "qa",
+    "dev",
+    "test",
+    "uat",
+    "sandbox",
+    "perf",
+)
+
+
+def _environment_from_url(url: str) -> str | None:
+    """Detect an environment name from keywords in a RAGFlow URL.
+
+    Case-insensitive substring scan over the URL exactly as given (scheme, host,
+    port and path all count). The first keyword in ENVIRONMENT_KEYWORDS to appear
+    wins, and the resolved value is the keyword itself, not the surrounding label:
+    'https://ims-dev.example.com/' -> 'dev'. Returns None when no keyword appears.
+    """
+    lowered = (url or "").lower()
+    for keyword in ENVIRONMENT_KEYWORDS:
+        if keyword in lowered:
+            return keyword
+    return None
 
 
 @dataclass
@@ -98,7 +123,12 @@ class RosettaConfig:
         RAGFLOW_PAGE_SIZE: Page size for listing operations (default: 1000)
         RAGFLOW_PARSE_TIMEOUT: Timeout for parsing operations in seconds (default: 1200)
         RAGFLOW_TIMEOUT: HTTP request timeout in seconds (default: 30)
-        ENVIRONMENT: Environment name (default: "local")
+        ENVIRONMENT: Environment display label. Takes precedence over URL keyword
+            detection, but not over an explicit --env argument. When unset, the
+            label is detected from RAGFLOW_BASE_URL by a case-insensitive scan for
+            the first of preprod, prod, stag, qa, dev, test, uat, sandbox, perf to
+            appear in it (the resolved value is that keyword itself, so
+            "https://ims-dev.example.com" yields "dev"); "local" if none appear.
     
     Examples:
         >>> config = RosettaConfig.from_env(".env")
@@ -194,9 +224,11 @@ class RosettaConfig:
         Args:
             environment: Optional explicit environment name (e.g., "local",
                 "dev", "remote"). If provided, this value is used and takes
-                precedence over the ENVIRONMENT environment variable. If not
-                provided, the ENVIRONMENT variable is used, defaulting to
-                "local" when unset.
+                precedence over everything else. If not provided, the
+                ENVIRONMENT variable is used; failing that, the label is
+                detected from a keyword in RAGFLOW_BASE_URL (see
+                ENVIRONMENT_KEYWORDS), defaulting to "local" when no keyword
+                appears.
         
         Returns:
             RosettaConfig instance
@@ -213,9 +245,11 @@ class RosettaConfig:
         api_key = os.getenv("RAGFLOW_API_KEY", "")
         dataset_default = os.getenv("RAGFLOW_DATASET_DEFAULT", "aia")
         dataset_template = os.getenv("RAGFLOW_DATASET_TEMPLATE", "aia-{release}")
-        # fallback to ENVIRONMENT env var, or default to "local"
+        # Environment is a display label only - nothing branches on its value.
+        # Precedence: explicit argument (--env) > ENVIRONMENT > keyword detected in
+        # the RAGFlow URL > "local".
         if not environment:
-            environment = os.getenv("ENVIRONMENT") or _first_subdomain(base_url) or "local"
+            environment = os.getenv("ENVIRONMENT") or _environment_from_url(base_url) or "local"
         
         # Dataset creation settings
         embedding_model = os.getenv("RAGFLOW_EMBEDDING_MODEL") or None

--- a/src/rosetta-cli/rosetta_cli/rosetta_publisher.py
+++ b/src/rosetta-cli/rosetta_cli/rosetta_publisher.py
@@ -641,13 +641,16 @@ class ContentPublisher:
                 return name[: -len(path.name)] + new_name
 
             # Collect all docs to delete into one list: (doc, label)
-            # Start with unmanaged: incomplete metadata (ims_doc_id or original_path absent)
+            # Start with managed docs carrying incomplete metadata: original_path is
+            # set (so the doc is ours) but ims_doc_id is absent. A doc with no
+            # original_path is custom/unmanaged and is never touched - see the
+            # docstring guarantee, which _cleanup_orphans enforces the same way.
             duplicates: list[tuple[DocumentLike, str]] = []
             for doc in all_docs:
                 meta = getattr(doc, "meta_fields", {}) or {}
                 ims_doc_id = meta.get("ims_doc_id") if isinstance(meta, dict) else getattr(meta, "ims_doc_id", None)
                 doc_original_path = meta.get("original_path", "") if isinstance(meta, dict) else getattr(meta, "original_path", "")
-                if not ims_doc_id or not doc_original_path:
+                if doc_original_path and not ims_doc_id:
                     doc_name = getattr(doc, "name", "") or doc.id
                     duplicates.append((doc, doc_name))
 
@@ -674,8 +677,10 @@ class ContentPublisher:
                     duplicates.append((doc, original_path))
 
             # Name duplicates: foo.md + foo(1).md + foo(2).md ...
+            # Grouped over managed_docs, not all_docs: a custom doc whose stripped
+            # name happens to collide with a managed one must not be deleted.
             name_groups: dict[str, list[DocumentLike]] = defaultdict(list)
-            for doc in all_docs:
+            for doc in managed_docs:
                 doc_name = getattr(doc, "name", "") or ""
                 if not doc_name:
                     continue

--- a/src/rosetta-cli/tests/test_parse_command_status_counts.py
+++ b/src/rosetta-cli/tests/test_parse_command_status_counts.py
@@ -16,16 +16,23 @@ class FakeDataset:
 
     def __init__(self, documents: list[FakeDocument]) -> None:
         self.documents = documents
+        self.list_documents_calls: list[int] = []
 
     def list_documents(self, page_size: int):
+        self.list_documents_calls.append(page_size)
         return self.documents
 
 
 class FakeDocumentService:
+    # Class-level so a test can assert the server-filtered path was never used,
+    # regardless of whether the command instantiates the service at all.
+    status_filter_calls: list[list[str]] = []
+
     def __init__(self, client: object) -> None:
         self.client = client
 
     def list_documents_by_status(self, dataset: FakeDataset, statuses: list[str], limit: int):
+        FakeDocumentService.status_filter_calls.append(list(statuses))
         return [
             document for document in dataset.documents
             if document.run in statuses
@@ -33,6 +40,7 @@ class FakeDocumentService:
 
 
 def _command(monkeypatch, documents: list[FakeDocument]) -> tuple[ParseCommand, FakeDataset]:
+    FakeDocumentService.status_filter_calls = []
     monkeypatch.setattr(
         "rosetta_cli.commands.parse_command.DocumentService",
         FakeDocumentService,
@@ -77,3 +85,72 @@ def test_default_mode_tallies_skipped_documents(monkeypatch) -> None:
 
     assert [document["id"] for document in docs_to_parse] == ["fail-1"]
     assert status_counts == {"done": 1, "running": 1}
+
+
+def test_default_mode_uses_one_unfiltered_list_call(monkeypatch) -> None:
+    """#305: default mode must not pair a server-filtered call with a full list."""
+    documents = [
+        FakeDocument("done-1", "DONE"),
+        FakeDocument("running-1", "RUNNING"),
+        FakeDocument("fail-1", "FAIL"),
+        FakeDocument("unstart-1", "UNSTART"),
+        FakeDocument("cancel-1", "CANCEL"),
+    ]
+    command, dataset = _command(monkeypatch, documents)
+
+    docs_to_parse, status_counts = command._get_documents_to_parse(
+        dataset,
+        Namespace(force=False),
+    )
+
+    # The server-side run= filter is gone; the partition happens client-side.
+    assert FakeDocumentService.status_filter_calls == []
+    # Exactly one RAGFlow round trip, at the configured page size.
+    assert dataset.list_documents_calls == [100]
+    # Selection and counts are unchanged by the consolidation.
+    assert [document["id"] for document in docs_to_parse] == [
+        "fail-1",
+        "unstart-1",
+        "cancel-1",
+    ]
+    assert [document["status"] for document in docs_to_parse] == [
+        "FAIL",
+        "UNSTART",
+        "CANCEL",
+    ]
+    assert status_counts == {"done": 1, "running": 1}
+
+
+def test_force_mode_uses_one_unfiltered_list_call(monkeypatch) -> None:
+    """#305: force mode keeps its single call and never consults the status filter."""
+    documents = [
+        FakeDocument("done-1", "DONE"),
+        FakeDocument("fail-1", "FAIL"),
+    ]
+    command, dataset = _command(monkeypatch, documents)
+
+    docs_to_parse, _ = command._get_documents_to_parse(
+        dataset,
+        Namespace(force=True),
+    )
+
+    assert FakeDocumentService.status_filter_calls == []
+    assert dataset.list_documents_calls == [100]
+    assert [document["id"] for document in docs_to_parse] == ["done-1", "fail-1"]
+
+
+def test_default_mode_ignores_statuses_that_do_not_need_parsing(monkeypatch) -> None:
+    """An unrecognised run value is not selected and not tallied as done/running."""
+    documents = [
+        FakeDocument("weird-1", "SOMETHING_ELSE"),
+        FakeDocument("fail-1", "FAIL"),
+    ]
+    command, dataset = _command(monkeypatch, documents)
+
+    docs_to_parse, status_counts = command._get_documents_to_parse(
+        dataset,
+        Namespace(force=False),
+    )
+
+    assert [document["id"] for document in docs_to_parse] == ["fail-1"]
+    assert status_counts == {"done": 0, "running": 0}

--- a/src/rosetta-cli/tests/test_publish_duplicate_cleanup.py
+++ b/src/rosetta-cli/tests/test_publish_duplicate_cleanup.py
@@ -1,0 +1,187 @@
+"""Regression tests for `_cleanup_duplicates` (issue #194).
+
+Its docstring promises "Custom documents (no original_path) are never affected".
+Before the fix, two passes broke that promise:
+
+* the incomplete-metadata pass queued any doc missing `ims_doc_id` **or**
+  `original_path`, so every custom doc was swept;
+* the name-duplicate pass grouped over `all_docs`, so a custom doc whose stripped
+  name collided with a managed one was swept too.
+
+The tests below pin both guarantees, and keep positive controls so the fix cannot
+be satisfied by simply deleting nothing.
+"""
+
+from types import SimpleNamespace
+
+# Reuse the fake RAGFlow harness that already backs the orphan-cleanup tests.
+from test_publish_domain_scoped_orphan_cleanup import (
+    _FakeClient,
+    _FakeDataset,
+    _FakeDoc,
+)
+
+from rosetta_cli.rosetta_publisher import ContentPublisher
+
+
+def _cache(original_path: str, release: str = "r2") -> SimpleNamespace:
+    """A local-file cache entry as `_cleanup_duplicates` consumes it."""
+    return SimpleNamespace(
+        original_path=original_path,
+        release=release,
+        ims_doc_id=f"ims-{original_path}",
+    )
+
+
+def _managed_doc(original_path: str, doc_id: str, name: str | None = None) -> _FakeDoc:
+    return _FakeDoc(
+        name=name if name is not None else original_path,
+        meta_fields={
+            "original_path": original_path,
+            "ims_doc_id": f"ims-{original_path}",
+            "release": "r2",
+        },
+        doc_id=doc_id,
+    )
+
+
+def _run_cleanup(docs: list[_FakeDoc], caches: list[SimpleNamespace], tmp_path):
+    dataset = _FakeDataset(docs=docs, dataset_id="aia-r2-id")
+    client = _FakeClient({"aia-r2": dataset})
+    publisher = ContentPublisher(client, str(tmp_path / "repo"))
+    publisher._cleanup_duplicates(caches, dry_run=False)
+    return dataset
+
+
+# --- the documented guarantee -------------------------------------------------
+
+
+def test_custom_document_without_original_path_is_never_deleted(tmp_path):
+    """#194: a hand-uploaded doc carrying no managed metadata must survive."""
+    custom = _FakeDoc(name="hand-uploaded.pdf", meta_fields={}, doc_id="custom-1")
+    managed = _managed_doc("r2/core/skills/planning/SKILL.md", doc_id="managed-1")
+
+    dataset = _run_cleanup(
+        [custom, managed],
+        [_cache("r2/core/skills/planning/SKILL.md")],
+        tmp_path,
+    )
+
+    assert dataset.deleted_ids == []
+
+
+def test_custom_document_with_partial_metadata_is_never_deleted(tmp_path):
+    """A doc with an ims_doc_id but no original_path is still not ours to delete."""
+    custom = _FakeDoc(
+        name="hand-uploaded.pdf",
+        meta_fields={"ims_doc_id": "some-id"},
+        doc_id="custom-1",
+    )
+
+    dataset = _run_cleanup(
+        [custom, _managed_doc("r2/core/agents/x.md", doc_id="managed-1")],
+        [_cache("r2/core/agents/x.md")],
+        tmp_path,
+    )
+
+    assert dataset.deleted_ids == []
+
+
+def test_custom_document_colliding_by_name_is_never_deleted(tmp_path):
+    """#194: the name-duplicate pass must not reach across into custom docs."""
+    managed = _managed_doc("r2/core/skills/planning/SKILL.md", doc_id="managed-1")
+    custom_collision = _FakeDoc(
+        name="r2/core/skills/planning/SKILL(1).md",
+        meta_fields={},
+        doc_id="custom-1",
+    )
+
+    dataset = _run_cleanup(
+        [managed, custom_collision],
+        [_cache("r2/core/skills/planning/SKILL.md")],
+        tmp_path,
+    )
+
+    assert dataset.deleted_ids == []
+
+
+# --- positive controls: real duplicates are still removed ---------------------
+
+
+def test_managed_document_missing_ims_doc_id_is_still_deleted(tmp_path):
+    """original_path present, ims_doc_id absent -> a stale managed doc."""
+    stale = _FakeDoc(
+        name="r2/core/agents/stale.md",
+        meta_fields={"original_path": "r2/core/agents/stale.md", "release": "r2"},
+        doc_id="stale-1",
+    )
+
+    dataset = _run_cleanup(
+        [stale],
+        [_cache("r2/core/skills/planning/SKILL.md")],
+        tmp_path,
+    )
+
+    assert dataset.deleted_ids == ["stale-1"]
+
+
+def test_duplicate_original_path_still_deletes_every_copy(tmp_path):
+    """Two managed docs sharing an original_path are both removed; publish recreates."""
+    first = _managed_doc("r2/core/agents/dup.md", doc_id="dup-1")
+    second = _managed_doc("r2/core/agents/dup.md", doc_id="dup-2")
+
+    dataset = _run_cleanup(
+        [first, second],
+        [_cache("r2/core/agents/dup.md")],
+        tmp_path,
+    )
+
+    assert sorted(dataset.deleted_ids) == ["dup-1", "dup-2"]
+
+
+def test_managed_name_duplicates_are_still_deleted(tmp_path):
+    """foo.md + foo(1).md, both managed, are still treated as name duplicates."""
+    original = _managed_doc("r2/core/agents/foo.md", doc_id="name-1")
+    suffixed = _managed_doc(
+        "r2/core/agents/foo-copy.md",
+        doc_id="name-2",
+        name="r2/core/agents/foo(1).md",
+    )
+
+    dataset = _run_cleanup(
+        [original, suffixed],
+        [_cache("r2/core/agents/foo.md")],
+        tmp_path,
+    )
+
+    assert sorted(dataset.deleted_ids) == ["name-1", "name-2"]
+
+
+def test_clean_dataset_deletes_nothing(tmp_path):
+    """No duplicates, no custom docs -> no deletions."""
+    dataset = _run_cleanup(
+        [
+            _managed_doc("r2/core/agents/a.md", doc_id="a"),
+            _managed_doc("r2/core/agents/b.md", doc_id="b"),
+        ],
+        [_cache("r2/core/agents/a.md"), _cache("r2/core/agents/b.md")],
+        tmp_path,
+    )
+
+    assert dataset.deleted_ids == []
+
+
+def test_dry_run_never_deletes(tmp_path):
+    """dry_run reports without touching the dataset."""
+    stale = _FakeDoc(
+        name="r2/core/agents/stale.md",
+        meta_fields={"original_path": "r2/core/agents/stale.md", "release": "r2"},
+        doc_id="stale-1",
+    )
+    dataset = _FakeDataset(docs=[stale], dataset_id="aia-r2-id")
+    client = _FakeClient({"aia-r2": dataset})
+    publisher = ContentPublisher(client, str(tmp_path / "repo"))
+
+    publisher._cleanup_duplicates([_cache("r2/core/agents/x.md")], dry_run=True)
+
+    assert dataset.deleted_ids == []

--- a/src/rosetta-cli/tests/test_rosetta_config_environment.py
+++ b/src/rosetta-cli/tests/test_rosetta_config_environment.py
@@ -87,6 +87,11 @@ def test_every_keyword_is_detectable(keyword):
         ("https://Ims-Stag.example.com", "stag"),
         # Scanned as given - scheme, port and path all count.
         ("http://10.0.0.5:8080/uat-api", "uat"),
+        # Substring matching also fires on incidental hits: a hostname that merely
+        # contains a keyword resolves to it. Inherent to "basic string contains";
+        # pinned so the behaviour is documented rather than discovered.
+        ("https://advantest.example.com", "test"),
+        ("https://prodigy.example.com", "prod"),
         ("", None),
     ],
 )

--- a/src/rosetta-cli/tests/test_rosetta_config_environment.py
+++ b/src/rosetta-cli/tests/test_rosetta_config_environment.py
@@ -1,0 +1,159 @@
+"""Environment-label resolution in RosettaConfig (issue #297).
+
+Precedence: explicit argument (--env) > ENVIRONMENT > keyword detected in
+RAGFLOW_BASE_URL > "local".
+
+Before the fix, detection took the URL's first subdomain, so the built-in default
+`http://ragflow.local` resolved to "ragflow" - contradicting both the documented
+default and the dataclass field default of "local". Nothing in this path had any
+test coverage.
+"""
+
+import pytest
+
+from rosetta_cli.rosetta_config import (
+    ENVIRONMENT_KEYWORDS,
+    RosettaConfig,
+    _environment_from_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_environment(monkeypatch):
+    """Isolate every test from the developer's own shell environment."""
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.delenv("RAGFLOW_BASE_URL", raising=False)
+    monkeypatch.setenv("RAGFLOW_API_KEY", "ragflow-test")
+
+
+# --- the keyword table itself -------------------------------------------------
+
+
+def test_environment_keyword_order_is_safe():
+    """ORDER IS LOAD-BEARING: a keyword containing another must be scanned first.
+
+    This guards the tuple against being alphabetized or sorted later. It derives
+    the containment pairs rather than hard-coding them, so it keeps holding if
+    keywords are added.
+    """
+    order = list(ENVIRONMENT_KEYWORDS)
+    for outer in order:
+        for inner in order:
+            if outer != inner and inner in outer:
+                assert order.index(outer) < order.index(inner), (
+                    f"{outer!r} contains {inner!r} and must be listed before it, "
+                    f"otherwise a URL containing {outer!r} resolves to {inner!r}"
+                )
+
+
+def test_prod_is_the_only_containment_pair():
+    """Documents why the tuple needs an order at all - if this fails, re-read
+    the ordering comment before adding the new keyword."""
+    pairs = {
+        (outer, inner)
+        for outer in ENVIRONMENT_KEYWORDS
+        for inner in ENVIRONMENT_KEYWORDS
+        if outer != inner and inner in outer
+    }
+    assert pairs == {("preprod", "prod")}
+
+
+@pytest.mark.parametrize("keyword", ENVIRONMENT_KEYWORDS)
+def test_every_keyword_is_detectable(keyword):
+    """Each keyword resolves to itself when it appears in a URL."""
+    assert _environment_from_url(f"https://ragflow-{keyword}.example.com") == keyword
+
+
+# --- detection from the URL ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        # The issue's own case: the built-in default must yield "local".
+        ("http://ragflow.local", None),
+        ("http://localhost:9380", None),
+        ("https://ragflow.example.com", None),
+        # Ordering guard - "prod" is a substring of "preprod".
+        ("https://preprod.example.com", "preprod"),
+        ("https://ragflow-preprod.corp.io/api", "preprod"),
+        ("https://prod.example.com", "prod"),
+        # The resolved value is the keyword, not the surrounding label. This is a
+        # deliberate change: previously "ims-dev.example.com" yielded "ims-dev".
+        ("https://ims-dev.example.com/", "dev"),
+        ("https://ims-qa.example.com", "qa"),
+        # Case-insensitive.
+        ("https://RAGFLOW-PROD.EXAMPLE.COM", "prod"),
+        ("https://Ims-Stag.example.com", "stag"),
+        # Scanned as given - scheme, port and path all count.
+        ("http://10.0.0.5:8080/uat-api", "uat"),
+        ("", None),
+    ],
+)
+def test_environment_from_url(url, expected):
+    assert _environment_from_url(url) == expected
+
+
+def test_first_match_wins_when_a_url_carries_two_keywords():
+    """Scan order decides, per the documented rule."""
+    assert _environment_from_url("https://dev-and-qa.example.com") == "qa"
+    assert ENVIRONMENT_KEYWORDS.index("qa") < ENVIRONMENT_KEYWORDS.index("dev")
+
+
+# --- end-to-end precedence through from_env_vars ------------------------------
+
+
+def test_bare_install_default_url_resolves_to_local():
+    """#297: only RAGFLOW_API_KEY set -> "local", not "ragflow"."""
+    config = RosettaConfig.from_env_vars()
+
+    assert config.base_url == "http://ragflow.local"
+    assert config.environment == "local"
+
+
+def test_bare_install_matches_the_dataclass_field_default():
+    """The resolver and the `environment: str = "local"` field default now agree."""
+    from_env = RosettaConfig.from_env_vars()
+    bare = RosettaConfig(base_url="http://ragflow.local", api_key="ragflow-test")
+
+    assert from_env.environment == bare.environment == "local"
+
+
+def test_url_without_any_keyword_resolves_to_local(monkeypatch):
+    monkeypatch.setenv("RAGFLOW_BASE_URL", "https://ragflow.internal.example.com")
+
+    assert RosettaConfig.from_env_vars().environment == "local"
+
+
+def test_prod_url_resolves_to_prod(monkeypatch):
+    monkeypatch.setenv("RAGFLOW_BASE_URL", "https://ragflow-prod.example.com")
+
+    assert RosettaConfig.from_env_vars().environment == "prod"
+
+
+def test_preprod_url_resolves_to_preprod_not_prod(monkeypatch):
+    """The ordering guard, end to end."""
+    monkeypatch.setenv("RAGFLOW_BASE_URL", "https://ragflow-preprod.example.com")
+
+    assert RosettaConfig.from_env_vars().environment == "preprod"
+
+
+def test_environment_variable_wins_over_url_detection(monkeypatch):
+    monkeypatch.setenv("RAGFLOW_BASE_URL", "https://ragflow-prod.example.com")
+    monkeypatch.setenv("ENVIRONMENT", "whatever-i-said")
+
+    assert RosettaConfig.from_env_vars().environment == "whatever-i-said"
+
+
+def test_explicit_argument_wins_over_environment_variable_and_url(monkeypatch):
+    """`--env` keeps top precedence."""
+    monkeypatch.setenv("RAGFLOW_BASE_URL", "https://ragflow-prod.example.com")
+    monkeypatch.setenv("ENVIRONMENT", "from-env-var")
+
+    config = RosettaConfig.from_env_vars(environment="from-cli-flag")
+
+    assert config.environment == "from-cli-flag"
+
+
+def test_explicit_argument_wins_for_the_default_url():
+    assert RosettaConfig.from_env_vars(environment="dev").environment == "dev"

--- a/src/rosetta-mcp-server/rosetta_mcp/analytics/tracker.py
+++ b/src/rosetta-mcp-server/rosetta_mcp/analytics/tracker.py
@@ -159,7 +159,9 @@ def track_tool_call(func: Callable[P, Awaitable[str]]) -> Callable[P, Awaitable[
         call_ctx = kwargs.get("call_ctx")
         repository = await get_repository_from_context(ctx) if ctx else "unknown"
         tool_name = func.__name__
-        agent_name, agent_version = get_agent_info_from_context(ctx)
+        agent_name, agent_version = (
+            get_agent_info_from_context(ctx) if ctx else ("unknown", "unknown")
+        )
 
         try:
             result = await func(*args, **kwargs)

--- a/src/rosetta-mcp-server/rosetta_mcp/analytics/user_context.py
+++ b/src/rosetta-mcp-server/rosetta_mcp/analytics/user_context.py
@@ -16,8 +16,9 @@ logger = logging.getLogger(__name__)
 _cached_username: str | None = None
 _STDIO_REPOSITORY_CACHE_KEY = "stdio"
 _repository_cache: TTLCache[str, str] = TTLCache(maxsize=1024, ttl=REPOSITORY_CACHE_TTL_SECONDS)
-_cached_agent_name: str | None = None
-_cached_agent_version: str | None = None
+_agent_info_cache: TTLCache[str, tuple[str, str]] = TTLCache(
+    maxsize=1024, ttl=REPOSITORY_CACHE_TTL_SECONDS
+)
 
 
 def get_username(call_ctx: Any = None) -> str:
@@ -127,10 +128,23 @@ async def get_repository_from_context(ctx: Any) -> str:
 
 
 def get_agent_info_from_context(ctx: Any) -> tuple[str, str]:
-    global _cached_agent_name, _cached_agent_version
-    if _cached_agent_name is not None and _cached_agent_version is not None:
-        return _cached_agent_name, _cached_agent_version
+    """Return the MCP client's (name, version), cached per session.
 
+    Keyed by the same session-scoped key as the repository cache: in HTTP mode
+    one process serves many clients, so process-wide caching reported the first
+    client's identity for every later session (#196).
+
+    Failed resolutions are deliberately not cached — otherwise a single
+    ctx-less call would pin ``"unknown"`` for the lifetime of the process.
+    Re-resolving is a plain attribute read on an in-memory session object.
+    """
+    cache_key = _repository_cache_key(ctx)
+    cached: tuple[str, str] | None = _agent_info_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    name = None
+    version = None
     try:
         client_info = (
             getattr(getattr(getattr(ctx, "session", None), "client_params", None), "clientInfo", None)
@@ -138,10 +152,12 @@ def get_agent_info_from_context(ctx: Any) -> tuple[str, str]:
         )
         name = getattr(client_info, "name", None) if client_info else None
         version = getattr(client_info, "version", None) if client_info else None
-        _cached_agent_name = name or "unknown"
-        _cached_agent_version = version or "unknown"
     except Exception:
-        _cached_agent_name = "unknown"
-        _cached_agent_version = "unknown"
+        pass
 
-    return _cached_agent_name, _cached_agent_version
+    if not name or not version:
+        return name or "unknown", version or "unknown"
+
+    result = (name, version)
+    _agent_info_cache[cache_key] = result
+    return result

--- a/src/rosetta-mcp-server/rosetta_mcp/clients/doc_cache.py
+++ b/src/rosetta-mcp-server/rosetta_mcp/clients/doc_cache.py
@@ -13,6 +13,7 @@ from cachetools import TTLCache
 
 from rosetta_mcp.clients.document import DocumentClient
 from rosetta_mcp.constants import DOC_CACHE_TTL_SECONDS
+from rosetta_mcp.tracing import _get_tool_timeout
 from rosetta_mcp.typing_utils import DatasetLike, DocumentLike
 
 
@@ -43,16 +44,22 @@ class InstructionDocCache:
         return docs
 
     async def get_all_docs_async(
-        self, dataset: DatasetLike, dataset_name: str, tool_timeout: int = 120
+        self, dataset: DatasetLike, dataset_name: str, tool_timeout: int | None = None
     ) -> list[DocumentLike]:
         """Async variant: cache check on event loop; blocking fetch off-loop (A4).
 
         Cache read/write happen on the event-loop thread (SPECS A-1).
         Only the sync RAGFlow list_docs is offloaded via asyncio.to_thread.
+
+        ``tool_timeout=None`` (the default) resolves the ceiling from
+        ``ROSETTA_TOOL_TIMEOUT`` via the same helper ``tracing.offload`` uses,
+        so callers do not have to plumb it through (#207). Falls back to
+        ``DEFAULT_TOOL_TIMEOUT`` when the env var is unset or invalid.
         """
         cached: list[DocumentLike] | None = self._cache.get(dataset_name)
         if cached is not None:
             return cached
+        timeout = _get_tool_timeout() if tool_timeout is None else tool_timeout
         # Offload only the blocking I/O, not the cache access (SPECS A-1).
         docs = await asyncio.wait_for(
             asyncio.to_thread(
@@ -62,7 +69,7 @@ class InstructionDocCache:
                     page_size=10000,
                 )
             ),
-            timeout=tool_timeout,
+            timeout=timeout,
         )
         # Write back on the event-loop thread (SPECS A-1).
         self._cache[dataset_name] = docs

--- a/src/rosetta-mcp-server/rosetta_mcp/migrations.py
+++ b/src/rosetta-mcp-server/rosetta_mcp/migrations.py
@@ -1,6 +1,7 @@
 """Redis schema migrations for Rosetta."""
 
 import logging
+import uuid
 from typing import Protocol
 
 logger = logging.getLogger(__name__)
@@ -24,6 +25,12 @@ class RosettaMigrations:
     Each migration is a method named ``_migrate_to_{version}``.
     On startup, reads the current version from Redis and executes
     only the migrations that haven't run yet, in sequence order.
+
+    Every ``_migrate_to_N`` MUST be idempotent. The distributed lock is
+    best-effort deduplication only: it carries a TTL and is never extended,
+    so a run that outlives the TTL loses it while still working. Idempotent
+    migrations plus the version re-read under the lock are what actually make
+    a rolling deploy safe.
     """
 
     LATEST_REDIS_SCHEMA_VERSION = 2  # bump when adding a new migration
@@ -50,10 +57,12 @@ class RosettaMigrations:
             self.LATEST_REDIS_SCHEMA_VERSION,
         )
 
-        # Acquire distributed lock with TTL to prevent concurrent migrations.
-        # SETNX + EX ensures the lock auto-expires if the holder crashes.
+        # Acquire distributed lock with TTL to deduplicate concurrent migrations.
+        # SETNX + EX ensures the lock auto-expires if the holder crashes. The
+        # value is a per-run token so release can be fenced (#209).
+        lock_token = uuid.uuid4().hex
         acquired = await self._redis.set(
-            self.LOCK_KEY, "1", nx=True, ex=self.LOCK_TTL_SECONDS
+            self.LOCK_KEY, lock_token, nx=True, ex=self.LOCK_TTL_SECONDS
         )
         if not acquired:
             logger.info("Migration lock held by another pod, skipping")
@@ -81,7 +90,35 @@ class RosettaMigrations:
                 "Redis migrations complete (version=%d)", self.LATEST_REDIS_SCHEMA_VERSION
             )
         finally:
-            await self._redis.delete(self.LOCK_KEY)
+            await self._release_lock(lock_token)
+
+    async def _release_lock(self, token: str) -> None:
+        """Delete the migration lock only while this run still owns it.
+
+        The lock has a 60 s TTL and is never extended, so a slow run can lose
+        it to another pod. An unconditional DELETE would then wipe that pod's
+        fresh lock and let two runs proceed together (#209). Comparing the
+        token first removes that window down to the sub-millisecond gap between
+        GET and DELETE; closing it fully would need a Lua CAS (and an ``eval``
+        on ``RedisClient``), which is not worth it for a once-per-process hook.
+        """
+        try:
+            raw = await self._redis.get(self.LOCK_KEY)
+        except Exception:
+            logger.warning("Could not read migration lock to release it", exc_info=True)
+            return
+        current: str | None = raw.decode() if isinstance(raw, bytes) else raw
+        if current is None:
+            logger.info("Migration lock already expired, nothing to release")
+            return
+        if current != token:
+            logger.warning(
+                "Migration lock no longer owned by this run (expired and re-acquired "
+                "elsewhere), leaving it in place"
+            )
+            return
+        await self._redis.delete(self.LOCK_KEY)
+        logger.info("Migration lock released")
 
     async def _get_redis_schema_version(self) -> int:
         raw = await self._redis.get(REDIS_SCHEMA_VERSION_KEY)

--- a/src/rosetta-mcp-server/tests/test_analytics.py
+++ b/src/rosetta-mcp-server/tests/test_analytics.py
@@ -1,11 +1,16 @@
 import unittest.mock as mock
+from types import SimpleNamespace
 
 import pytest
 
 import rosetta_mcp.analytics.tracker as tracker_module
 import rosetta_mcp.analytics.user_context as user_context_module
 from rosetta_mcp.analytics.tracker import capture_error_to_posthog, get_client_ip, track_tool_call
-from rosetta_mcp.analytics.user_context import get_authenticated_identity, get_repository_from_context
+from rosetta_mcp.analytics.user_context import (
+    get_agent_info_from_context,
+    get_authenticated_identity,
+    get_repository_from_context,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -79,8 +84,9 @@ _SENTINEL_CTX = object()  # non-None; signals "we are in an HTTP request context
 # ---------------------------------------------------------------------------
 
 @pytest.fixture(autouse=True)
-def _clear_repository_cache():
+def _clear_context_caches():
     user_context_module._repository_cache.clear()
+    user_context_module._agent_info_cache.clear()
 
 
 @pytest.mark.asyncio
@@ -722,3 +728,133 @@ async def test_track_tool_call_performance_rating_buckets(monkeypatch, sleep_ms,
 
     web_vitals = next(e for e in posthog.captured if e["event"] == "$web_vitals")
     assert web_vitals["properties"]["performance_rating"] == expected_rating
+
+
+# ---------------------------------------------------------------------------
+# get_agent_info_from_context — per-session scoping (issue #196)
+# ---------------------------------------------------------------------------
+
+class _FakeClientInfo:
+    def __init__(self, name: str | None, version: str | None):
+        if name is not None:
+            self.name = name
+        if version is not None:
+            self.version = version
+
+
+class _FakeAgentContext:
+    """Context exposing both what get_agent_info_from_context reads
+    (``session.client_params.clientInfo``) and what the cache key reads
+    (``request_context.request`` + ``session_id``)."""
+
+    def __init__(
+        self,
+        name: str | None = None,
+        version: str | None = None,
+        session_id: str | None = None,
+        http: bool = False,
+        session_raises: bool = False,
+    ):
+        self.client_info = (
+            _FakeClientInfo(name, version) if (name is not None or version is not None) else None
+        )
+        self._session_raises = session_raises
+        self.request_context = SimpleNamespace(
+            request=_FakeRequest(session_id or "missing") if http else None
+        )
+        self._session_id = session_id
+
+    @property
+    def session(self):
+        if self._session_raises:
+            raise RuntimeError("no active session")
+        return SimpleNamespace(client_params=SimpleNamespace(clientInfo=self.client_info))
+
+    @property
+    def session_id(self) -> str:
+        if self._session_id is None:
+            raise RuntimeError("no session id")
+        return self._session_id
+
+
+def test_agent_info_is_keyed_by_http_session():
+    """Two HTTP sessions from different MCP clients must not share agent info."""
+    ctx_a = _FakeAgentContext("claude-code", "1.0", session_id="session-a", http=True)
+    ctx_b = _FakeAgentContext("cursor", "2.5", session_id="session-b", http=True)
+
+    assert get_agent_info_from_context(ctx_a) == ("claude-code", "1.0")
+    assert get_agent_info_from_context(ctx_b) == ("cursor", "2.5")
+    # And back again — each session keeps its own value.
+    assert get_agent_info_from_context(ctx_a) == ("claude-code", "1.0")
+
+
+def test_agent_info_is_cached_per_session():
+    """A resolved session is cached: later reads do not re-inspect clientInfo."""
+    ctx = _FakeAgentContext("claude-code", "1.0", session_id="session-a", http=True)
+
+    assert get_agent_info_from_context(ctx) == ("claude-code", "1.0")
+    ctx.client_info = _FakeClientInfo("mutated", "9.9")
+    assert get_agent_info_from_context(ctx) == ("claude-code", "1.0")
+
+
+def test_agent_info_unknown_is_not_cached_for_the_process():
+    """A ctx-less call must not pin "unknown" for every later session."""
+    assert get_agent_info_from_context(None) == ("unknown", "unknown")
+
+    ctx = _FakeAgentContext("claude-code", "1.0", session_id="session-a", http=True)
+    assert get_agent_info_from_context(ctx) == ("claude-code", "1.0")
+
+
+def test_agent_info_session_error_is_not_cached():
+    """A session that raises must not poison later sessions either."""
+    broken = _FakeAgentContext(session_id="session-a", http=True, session_raises=True)
+    assert get_agent_info_from_context(broken) == ("unknown", "unknown")
+
+    ctx = _FakeAgentContext("cursor", "2.5", session_id="session-b", http=True)
+    assert get_agent_info_from_context(ctx) == ("cursor", "2.5")
+
+
+def test_agent_info_partial_client_info_is_not_cached():
+    """Missing version resolves to "unknown" without being cached."""
+    ctx = _FakeAgentContext("claude-code", None, session_id="session-a", http=True)
+    assert get_agent_info_from_context(ctx) == ("claude-code", "unknown")
+
+    ctx.client_info = _FakeClientInfo("claude-code", "1.0")
+    assert get_agent_info_from_context(ctx) == ("claude-code", "1.0")
+
+
+def test_agent_info_stdio_shares_a_singleton_key():
+    """STDIO/local transports intentionally share one key (single-user process)."""
+    ctx = _FakeAgentContext("claude-code", "1.0")  # http=False → no request
+    assert get_agent_info_from_context(ctx) == ("claude-code", "1.0")
+
+    other = _FakeAgentContext("cursor", "2.5")
+    assert get_agent_info_from_context(other) == ("claude-code", "1.0")
+
+
+@pytest.mark.asyncio
+async def test_track_tool_call_does_not_resolve_agent_info_without_ctx(monkeypatch):
+    """tracker must not call the resolver with ctx=None (mirrors the repository guard)."""
+    posthog = _FakePosthog()
+    monkeypatch.setattr(tracker_module, "get_posthog_client", lambda config=None: posthog)
+    monkeypatch.setattr(
+        tracker_module,
+        "get_repository_from_context",
+        mock.AsyncMock(return_value="repo"),
+    )
+    calls: list[object] = []
+
+    def _resolver(ctx):
+        calls.append(ctx)
+        return ("claude-code", "1.0")
+
+    monkeypatch.setattr(tracker_module, "get_agent_info_from_context", _resolver)
+
+    @track_tool_call
+    async def my_tool(ctx=None):
+        return "ok"
+
+    await my_tool(ctx=None)
+
+    assert calls == []
+    assert posthog.captured[0]["properties"]["$browser"] == "unknown"

--- a/src/rosetta-mcp-server/tests/test_doc_cache.py
+++ b/src/rosetta-mcp-server/tests/test_doc_cache.py
@@ -12,6 +12,7 @@ import time
 import pytest
 
 from rosetta_mcp.clients.doc_cache import InstructionDocCache
+from rosetta_mcp.constants import DEFAULT_TOOL_TIMEOUT
 
 
 class _FakeDocumentClient:
@@ -111,3 +112,69 @@ async def test_get_all_docs_async_invalidate_forces_refetch():
 
     await cache.get_all_docs_async(dataset, "ds1", tool_timeout=5)
     assert fake.calls == 2
+
+
+# ---------------------------------------------------------------------------
+# ROSETTA_TOOL_TIMEOUT resolution (issue #207)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def recorded_wait_for(monkeypatch):
+    """Record the timeout passed to asyncio.wait_for, then delegate to the real one."""
+    recorded: dict[str, float] = {}
+    real_wait_for = asyncio.wait_for
+
+    async def _spy(awaitable, timeout=None):
+        recorded["timeout"] = timeout
+        return await real_wait_for(awaitable, timeout)
+
+    monkeypatch.setattr(asyncio, "wait_for", _spy)
+    return recorded
+
+
+@pytest.mark.asyncio
+async def test_get_all_docs_async_default_timeout_honors_env(monkeypatch, recorded_wait_for):
+    """With tool_timeout omitted, ROSETTA_TOOL_TIMEOUT must be honored (issue #207)."""
+    monkeypatch.setenv("ROSETTA_TOOL_TIMEOUT", "7")
+    fake = _FakeDocumentClient(docs=["doc1"])
+    cache = InstructionDocCache(document_client=fake, ttl=300)
+
+    assert await cache.get_all_docs_async(object(), "ds1") == ["doc1"]
+    assert recorded_wait_for["timeout"] == 7
+
+
+@pytest.mark.asyncio
+async def test_get_all_docs_async_default_timeout_unchanged_without_env(
+    monkeypatch, recorded_wait_for
+):
+    """No env var set: the effective timeout stays DEFAULT_TOOL_TIMEOUT (issue #207)."""
+    monkeypatch.delenv("ROSETTA_TOOL_TIMEOUT", raising=False)
+    fake = _FakeDocumentClient(docs=["doc1"])
+    cache = InstructionDocCache(document_client=fake, ttl=300)
+
+    assert await cache.get_all_docs_async(object(), "ds1") == ["doc1"]
+    assert recorded_wait_for["timeout"] == DEFAULT_TOOL_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_get_all_docs_async_explicit_timeout_overrides_env(monkeypatch, recorded_wait_for):
+    """An explicit tool_timeout still wins over the env var (issue #207)."""
+    monkeypatch.setenv("ROSETTA_TOOL_TIMEOUT", "7")
+    fake = _FakeDocumentClient(docs=["doc1"])
+    cache = InstructionDocCache(document_client=fake, ttl=300)
+
+    assert await cache.get_all_docs_async(object(), "ds1", tool_timeout=5) == ["doc1"]
+    assert recorded_wait_for["timeout"] == 5
+
+
+@pytest.mark.asyncio
+async def test_get_all_docs_async_invalid_env_falls_back_to_default(
+    monkeypatch, recorded_wait_for
+):
+    """A non-numeric ROSETTA_TOOL_TIMEOUT falls back to the default (issue #207)."""
+    monkeypatch.setenv("ROSETTA_TOOL_TIMEOUT", "not-a-number")
+    fake = _FakeDocumentClient(docs=["doc1"])
+    cache = InstructionDocCache(document_client=fake, ttl=300)
+
+    assert await cache.get_all_docs_async(object(), "ds1") == ["doc1"]
+    assert recorded_wait_for["timeout"] == DEFAULT_TOOL_TIMEOUT

--- a/src/rosetta-mcp-server/tests/test_migrations.py
+++ b/src/rosetta-mcp-server/tests/test_migrations.py
@@ -131,3 +131,107 @@ async def test_migrate_to_2_ignores_other_keys():
     m = RosettaMigrations(redis_client=redis)
     await m._migrate_to_2()
     assert unrelated_key in redis._store
+
+
+# ---------------------------------------------------------------------------
+# Lock fencing (issue #209)
+# ---------------------------------------------------------------------------
+
+class BytesFakeRedis(FakeRedis):
+    """FakeRedis whose GET returns bytes, as a client without decode_responses would."""
+
+    async def get(self, key: str) -> bytes | None:  # type: ignore[override]
+        value = self._store.get(key)
+        return None if value is None else value.encode()
+
+
+@pytest.mark.asyncio
+async def test_migration_lock_value_is_a_unique_token():
+    """The lock is acquired with a per-run token, not a constant (issue #209)."""
+    observed: list[str] = []
+
+    async def _run_and_capture() -> None:
+        redis = FakeRedis()
+        m = RosettaMigrations(redis_client=redis)
+
+        async def _spy_migrate_to_1() -> None:
+            observed.append(redis._store[RosettaMigrations.LOCK_KEY])
+
+        m._migrate_to_1 = _spy_migrate_to_1  # type: ignore[method-assign]
+        await m.run()
+
+    await _run_and_capture()
+    await _run_and_capture()
+
+    assert len(observed) == 2
+    assert all(token and token != "1" for token in observed)
+    assert observed[0] != observed[1]
+
+
+@pytest.mark.asyncio
+async def test_migration_release_does_not_delete_another_holders_lock():
+    """A run whose lock expired must not delete the lock a second pod now holds.
+
+    Simulates the TTL-expiry steal: mid-run, the lock key is overwritten with a
+    foreign token. The unconditional DELETE in the ``finally`` used to wipe it,
+    letting two pods migrate concurrently (issue #209).
+    """
+    redis = FakeRedis()
+    m = RosettaMigrations(redis_client=redis)
+
+    async def _steal_lock() -> None:
+        redis._store[RosettaMigrations.LOCK_KEY] = "other-pod-token"
+
+    m._migrate_to_1 = _steal_lock  # type: ignore[method-assign]
+
+    await m.run()
+
+    assert redis._store.get(RosettaMigrations.LOCK_KEY) == "other-pod-token"
+    assert int(redis._store[REDIS_SCHEMA_VERSION_KEY]) == RosettaMigrations.LATEST_REDIS_SCHEMA_VERSION
+
+
+@pytest.mark.asyncio
+async def test_migration_release_does_not_delete_foreign_lock_on_error():
+    """Same fencing on the failure path — the ``finally`` must still compare."""
+    redis = FakeRedis()
+    m = RosettaMigrations(redis_client=redis)
+
+    async def _steal_then_fail() -> None:
+        redis._store[RosettaMigrations.LOCK_KEY] = "other-pod-token"
+        raise RuntimeError("migration failure")
+
+    m._migrate_to_1 = _steal_then_fail  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="migration failure"):
+        await m.run()
+
+    assert redis._store.get(RosettaMigrations.LOCK_KEY) == "other-pod-token"
+
+
+@pytest.mark.asyncio
+async def test_migration_release_tolerates_expired_lock():
+    """If the lock already expired, release is a no-op and run() still succeeds."""
+    redis = FakeRedis()
+    m = RosettaMigrations(redis_client=redis)
+
+    async def _expire_lock() -> None:
+        redis._store.pop(RosettaMigrations.LOCK_KEY, None)
+
+    m._migrate_to_1 = _expire_lock  # type: ignore[method-assign]
+
+    await m.run()
+
+    assert RosettaMigrations.LOCK_KEY not in redis._store
+    assert int(redis._store[REDIS_SCHEMA_VERSION_KEY]) == RosettaMigrations.LATEST_REDIS_SCHEMA_VERSION
+
+
+@pytest.mark.asyncio
+async def test_migration_lock_released_when_get_returns_bytes():
+    """Ownership comparison works against a client that returns raw bytes."""
+    redis = BytesFakeRedis()
+    m = RosettaMigrations(redis_client=redis)
+
+    await m.run()
+
+    assert RosettaMigrations.LOCK_KEY not in redis._store
+    assert int(redis._store[REDIS_SCHEMA_VERSION_KEY]) == RosettaMigrations.LATEST_REDIS_SCHEMA_VERSION

--- a/src/rosetta-mcp-server/tests/test_tool_contracts.py
+++ b/src/rosetta-mcp-server/tests/test_tool_contracts.py
@@ -37,7 +37,7 @@ class _InstructionDocCache:
         self.calls.append((dataset, dataset_name))
         return self.docs
 
-    async def get_all_docs_async(self, dataset, dataset_name: str, tool_timeout: int = 120):
+    async def get_all_docs_async(self, dataset, dataset_name: str, tool_timeout: int | None = None):
         self.calls.append((dataset, dataset_name))
         return self.docs
 

--- a/src/rosettify-plugins/package-lock.json
+++ b/src/rosettify-plugins/package-lock.json
@@ -24,6 +24,7 @@
         "@types/micromatch": "^4.0.10",
         "@types/node": "^25.5.2",
         "@vitest/coverage-v8": "^4.1.10",
+        "smol-toml": "^1.8.0",
         "tsx": "^4.19.4",
         "typescript": "^6.0.0",
         "vitest": "^4.1.10"
@@ -2189,6 +2190,19 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
     },
     "node_modules/sonic-boom": {
       "version": "4.2.1",

--- a/src/rosettify-plugins/package-lock.json
+++ b/src/rosettify-plugins/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rosettify-plugins",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rosettify-plugins",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^14.0.3",

--- a/src/rosettify-plugins/package.json
+++ b/src/rosettify-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rosettify-plugins",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Generate Rosetta IDE plugin outputs from instruction sources via CLI or library API",
   "license": "Apache-2.0",
   "author": "isolomatovgd",

--- a/src/rosettify-plugins/package.json
+++ b/src/rosettify-plugins/package.json
@@ -50,6 +50,7 @@
     "@types/micromatch": "^4.0.10",
     "@types/node": "^25.5.2",
     "@vitest/coverage-v8": "^4.1.10",
+    "smol-toml": "^1.8.0",
     "tsx": "^4.19.4",
     "typescript": "^6.0.0",
     "vitest": "^4.1.10"

--- a/src/rosettify-plugins/src/serialize/toml.ts
+++ b/src/rosettify-plugins/src/serialize/toml.ts
@@ -15,13 +15,75 @@ function tomlStringEscape(s: string): string {
 }
 
 /**
+ * Escape a body for embedding in a TOML multi-line BASIC string (`"""`).
+ *
+ * `"""` is the multi-line *basic* form, so the parser processes escape sequences inside it — a raw
+ * body is NOT passed through verbatim. Two things break an unescaped body (NFR-0001: "any generated
+ * subagent TOML, when parsed, parsing succeeds"):
+ *   - a backslash that does not open a valid escape sequence is a hard parse error (`regex \d+`),
+ *     and one that does (`literal \n`) is silently rewritten into a different value;
+ *   - a run of three or more quotation marks terminates the string early.
+ *
+ * Escaping applied, in one pass:
+ *   - `\` → `\\` (every backslash, so no accidental escape sequence survives)
+ *   - a run of >= 3 quotation marks → every third one escaped (`"""` → `""\"`), the idiom TOML
+ *     1.0.0 itself uses. Runs of 1-2 are legal unescaped and are left alone, which keeps already
+ *     committed output byte-identical.
+ *   - CR/BS/FF and the remaining C0 controls + DEL → `\r`/`\b`/`\f`/`\uXXXX`. Only tab and line
+ *     feed may appear literally inside a multi-line basic string.
+ *
+ * Embedding contract: the caller must place the body between a newline and a newline —
+ * `"""\n<escaped body>\n"""`, exactly emitCodexToml's layout. That newline before the closing
+ * delimiter is why a trailing quote run in the body never abuts the delimiter, so the "1-3 quotes
+ * just inside the closing delimiter" case cannot arise here and is not handled.
+ */
+export function tomlMultilineBodyEscape(body: string): string {
+  let result = '';
+  for (let i = 0; i < body.length; ) {
+    const ch = body[i] as string;
+    if (ch === '\\') {
+      result += '\\\\';
+      i += 1;
+      continue;
+    }
+    if (ch === '"') {
+      let run = 0;
+      while (i + run < body.length && body[i + run] === '"') run += 1;
+      if (run < 3) {
+        result += '"'.repeat(run);
+      } else {
+        for (let n = 1; n <= run; n += 1) result += n % 3 === 0 ? '\\"' : '"';
+      }
+      i += run;
+      continue;
+    }
+    const code = body.charCodeAt(i);
+    if (ch === '\n' || ch === '\t') {
+      result += ch;
+    } else if (ch === '\r') {
+      result += '\\r';
+    } else if (code === 0x08) {
+      result += '\\b';
+    } else if (code === 0x0c) {
+      result += '\\f';
+    } else if (code < 0x20 || code === 0x7f) {
+      result += '\\u' + code.toString(16).padStart(4, '0');
+    } else {
+      result += ch;
+    }
+    i += 1;
+  }
+  return result;
+}
+
+/**
  * Emit codex agent TOML with exact field order per GT-6.
  * name, description, developer_instructions (""" multiline), model?, model_reasoning_effort?, sandbox_mode
  */
 export interface CodexTomlFields {
   name: string;
   description: string;
-  developerInstructions: string; // the body text (may contain """)
+  developerInstructions: string; // the body text; any content, escaped on emit
   model?: string;
   modelReasoningEffort?: string;
   sandboxMode: string; // "workspace-write" | "read-only"
@@ -33,13 +95,12 @@ export function emitCodexToml(fields: CodexTomlFields): string {
   lines.push(`name = "${tomlStringEscape(fields.name)}"`);
   lines.push(`description = "${tomlStringEscape(fields.description)}"`);
 
-  // Multi-line literal block with """. Body starts on next line after opening """.
-  // GT-6: opening """ followed by newline, body, newline, closing """
-  // Note: if body contains """, we need to escape it — TOML multiline basic strings
-  // can escape """ as """ with a backslash continuation, but baseline uses raw body.
-  // Decode: the body goes verbatim between the delimiters.
+  // Multi-line BASIC block with """ (`'''` is TOML's literal form; this is not it, so escape
+  // sequences ARE processed inside the delimiters). Body starts on the next line after the
+  // opening """. GT-6: opening """ followed by newline, body, newline, closing """.
+  // The body is escaped for that context — see tomlMultilineBodyEscape.
   lines.push(`developer_instructions = """`);
-  lines.push(fields.developerInstructions);
+  lines.push(tomlMultilineBodyEscape(fields.developerInstructions));
   lines.push(`"""`);
 
   if (fields.model !== undefined) {

--- a/src/rosettify-plugins/src/serialize/toml.ts
+++ b/src/rosettify-plugins/src/serialize/toml.ts
@@ -18,7 +18,7 @@ function tomlStringEscape(s: string): string {
  * Escape a body for embedding in a TOML multi-line BASIC string (`"""`).
  *
  * `"""` is the multi-line *basic* form, so the parser processes escape sequences inside it — a raw
- * body is NOT passed through verbatim. Two things break an unescaped body (NFR-0001: "any generated
+ * body is NOT passed through verbatim. Two things break an unescaped body (NFR-0005: "any generated
  * subagent TOML, when parsed, parsing succeeds"):
  *   - a backslash that does not open a valid escape sequence is a hard parse error (`regex \d+`),
  *     and one that does (`literal \n`) is silently rewritten into a different value;

--- a/src/rosettify-plugins/src/spec/model-maps.ts
+++ b/src/rosettify-plugins/src/spec/model-maps.ts
@@ -341,6 +341,13 @@ const COPILOT_GEMINI_MAP: Record<string, string> = {
   'gemini-3.7-flash': 'Gemini 3.7 Flash',
   'gemini-3.1-pro-preview': 'Gemini 3.7 Flash',
   'gemini-3.1-pro': 'Gemini 3.7 Flash',
+  // FR-ARCH-0057 key-retention invariant: a superseded token keeps its key and resolves FORWARD to
+  // the current model of its own cost tier. CURSOR_GEMINI_MAP has carried gemini-3.5-flash since the
+  // forward-upgrade rewrite; Copilot's omission was the only unexplained asymmetry between the two
+  // vocabularies (the missing grok-*/composer-* keys are deliberate — see the note above
+  // COPILOT_VOCABULARY). Value is `Gemini 3.7 Flash`, NOT `Gemini 3.5 Flash`: pinning the superseded
+  // model on Copilot while Cursor upgrades it would create a divergence, not close one.
+  'gemini-3.5-flash': 'Gemini 3.7 Flash',
   'gemini-3-flash': 'Gemini 3.7 Flash',
   'gemini-3-flash-preview': 'Gemini 3.7 Flash',
 };
@@ -453,7 +460,7 @@ export const CLAUDE_VOCABULARY: ModelVocabulary = {
 
 // Cursor/Copilot merge their per-vendor maps into one flat map consulted by exact-token lookup.
 // Keys are disjoint across the source maps (claude-*/gpt-*/gemini-*/grok-*/composer-* prefixes never
-// collide — verified: Cursor 65 total keys, 65 unique; Copilot 58 total, 58 unique), so merge order
+// collide — verified: Cursor 65 total keys, 65 unique; Copilot 59 total, 59 unique), so merge order
 // is immaterial.
 //
 // The Copilot map carries no Grok or Composer entry. That records only that no Copilot-native

--- a/src/rosettify-plugins/tests/e2e/profile.e2e.test.ts
+++ b/src/rosettify-plugins/tests/e2e/profile.e2e.test.ts
@@ -70,7 +70,7 @@ function buildSources(outputDir: string): ResolvedSources {
 }
 
 /**
- * NFR-0001 (#271) — "Given: any generated subagent TOML When: parsed Then: parsing succeeds."
+ * NFR-0005 (#271) — "Given: any generated subagent TOML When: parsed Then: parsing succeeds."
  *
  * Both real-repo builds in this file emit a full `.codex/agents/*.toml` set from the live
  * instruction tree, so the acceptance criterion is checked here for free rather than paying for a
@@ -230,7 +230,7 @@ describe('Profile E2E — profiled build (--profile lightweight)', () => {
     expect(codexEngineer).toContain('model_reasoning_effort = "xhigh"');
   });
 
-  it('every emitted core-codex-light agent TOML parses (NFR-0001, #271)', () => {
+  it('every emitted core-codex-light agent TOML parses (NFR-0005, #271)', () => {
     expectEveryCodexAgentTomlParses(outputDir, 'core-codex-light');
   });
 
@@ -300,7 +300,7 @@ describe('Profile E2E — no-profile run (regression guard, FR-PROF-0040)', () =
     expect(codexEngineer).toContain('model_reasoning_effort = "medium"');
   });
 
-  it('every emitted core-codex agent TOML parses (NFR-0001, #271)', () => {
+  it('every emitted core-codex agent TOML parses (NFR-0005, #271)', () => {
     expectEveryCodexAgentTomlParses(outputDir, 'core-codex');
   });
 

--- a/src/rosettify-plugins/tests/e2e/profile.e2e.test.ts
+++ b/src/rosettify-plugins/tests/e2e/profile.e2e.test.ts
@@ -191,17 +191,22 @@ describe('Profile E2E — profiled build (--profile lightweight)', () => {
   // exact-token tier and its family-substring fallback, Cursor's and Copilot's first-token exact
   // match, and Codex's first-gpt-token match plus reasoning-effort split.
   it('light agents resolve to the profile-scoped models on all four vocabularies', () => {
-    // Claude, exact-token tier: architect's light list carries claude-5-opus-high, which the Claude
-    // map resolves by EXACT token. The `opus` family key resolves to the same value, so this agrees
-    // with the base build rather than diverging from it — Claude Code exposes three tiers and the
-    // light profile asks for the same one here. What the exact entry guarantees is that an author
-    // naming a version explicitly keeps getting THAT version even if the family default later moves.
+    // Claude, exact-token tier: architect's light list carries claude-opus-5, which the Claude map
+    // resolves by EXACT token (#178 normalized the source token from claude-5-opus-high; both forms
+    // are exact keys and both resolve here, so the tier this exercises did not change). The `opus`
+    // family key resolves to the same value, so this agrees with the base build rather than diverging
+    // from it — Claude Code exposes three tiers and the light profile asks for the same one here.
+    // What the exact entry guarantees is that an author naming a version explicitly keeps getting
+    // THAT version even if the family default later moves.
     const claudeArchitect = fs.readFileSync(
       path.join(outputDir, 'core-claude-light', 'agents', 'architect.md'), 'utf-8');
     expect(claudeArchitect).toMatch(/^model: claude-opus-5$/m);
 
-    // Claude, family fallback: discoverer's light list carries claude-4.5-haiku, no exact entry, so
-    // the haiku family key resolves it (the base list leads with claude-5-sonnet -> claude-sonnet-5).
+    // Claude, family fallback: discoverer's light list carries claude-haiku-4-5. CLAUDE_CODE_MAP has
+    // exact keys only for the opus tokens, so this still has no exact entry and the `haiku` family
+    // key resolves it — #178's source normalization (claude-4.5-haiku -> claude-haiku-4-5) kept this
+    // case on the family tier, so the family-substring fallback remains covered by the real source
+    // tree. (The base list leads with claude-sonnet-5, also family-resolved, via `sonnet`.)
     const claudeDiscoverer = fs.readFileSync(
       path.join(outputDir, 'core-claude-light', 'agents', 'discoverer.md'), 'utf-8');
     expect(claudeDiscoverer).toMatch(/^model: claude-haiku-4-5$/m);

--- a/src/rosettify-plugins/tests/e2e/profile.e2e.test.ts
+++ b/src/rosettify-plugins/tests/e2e/profile.e2e.test.ts
@@ -27,6 +27,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { parse as parseToml } from 'smol-toml';
 import { generate } from '../../src/index.js';
 import type { ResolvedSources } from '../../src/types.js';
 
@@ -66,6 +67,36 @@ function buildSources(outputDir: string): ResolvedSources {
     outputDir,
     profileSource: PROFILE_SOURCE,
   };
+}
+
+/**
+ * NFR-0001 (#271) — "Given: any generated subagent TOML When: parsed Then: parsing succeeds."
+ *
+ * Both real-repo builds in this file emit a full `.codex/agents/*.toml` set from the live
+ * instruction tree, so the acceptance criterion is checked here for free rather than paying for a
+ * third generate() run. This is the poka-yoke for the whole class of emitter defects: the moment a
+ * maintainer authors an agent body containing a backslash (a regex, a Windows path) or a literal
+ * triple-quote, this fails in CI instead of shipping a Codex plugin that won't load.
+ */
+function expectEveryCodexAgentTomlParses(outputDir: string, codexTargetDir: string): void {
+  const agentsDir = path.join(outputDir, codexTargetDir, '.codex', 'agents');
+  expect(fs.existsSync(agentsDir), `${agentsDir} must exist`).toBe(true);
+  const files = fs.readdirSync(agentsDir).filter((f) => f.endsWith('.toml'));
+  // Guard against the assertion silently passing on an empty directory.
+  expect(files.length, 'expected a non-empty set of emitted agent TOMLs').toBeGreaterThan(0);
+  for (const file of files) {
+    const full = path.join(agentsDir, file);
+    const raw = fs.readFileSync(full, 'utf-8');
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = parseToml(raw) as Record<string, unknown>;
+    } catch (err) {
+      throw new Error(`${codexTargetDir}/.codex/agents/${file} is not valid TOML: ${String(err)}`);
+    }
+    // A parse that yields no body would mean the block collapsed — assert the field is really there.
+    expect(typeof parsed.developer_instructions, `${file} developer_instructions`).toBe('string');
+    expect((parsed.developer_instructions as string).length, `${file} body`).toBeGreaterThan(0);
+  }
 }
 
 function listFilesRecursive(dir: string): string[] {
@@ -194,6 +225,10 @@ describe('Profile E2E — profiled build (--profile lightweight)', () => {
     expect(codexEngineer).toContain('model_reasoning_effort = "xhigh"');
   });
 
+  it('every emitted core-codex-light agent TOML parses (NFR-0001, #271)', () => {
+    expectEveryCodexAgentTomlParses(outputDir, 'core-codex-light');
+  });
+
   it('light manifest name carries the -light suffix (FR-PROF-0021.AC1)', () => {
     const manifestPath = path.join(outputDir, 'core-claude-light', '.claude-plugin', 'plugin.json');
     expect(fs.existsSync(manifestPath)).toBe(true);
@@ -258,6 +293,10 @@ describe('Profile E2E — no-profile run (regression guard, FR-PROF-0040)', () =
       path.join(outputDir, 'core-codex', '.codex', 'agents', 'engineer.toml'), 'utf-8');
     expect(codexEngineer).toContain('model = "gpt-5.6-terra"');
     expect(codexEngineer).toContain('model_reasoning_effort = "medium"');
+  });
+
+  it('every emitted core-codex agent TOML parses (NFR-0001, #271)', () => {
+    expectEveryCodexAgentTomlParses(outputDir, 'core-codex');
   });
 
   it('base manifest name carries no suffix (FR-PROF-0040.AC2)', () => {

--- a/src/rosettify-plugins/tests/unit/file-processors/file-codex-agent.test.ts
+++ b/src/rosettify-plugins/tests/unit/file-processors/file-codex-agent.test.ts
@@ -1,5 +1,6 @@
 // FR-ARCH-0044 — fileCodexAgentFormat: produces TOML, sandbox from readonly, field order GT-6
 import { describe, it, expect } from 'vitest';
+import { parse as parseToml } from 'smol-toml';
 import { fileCodexAgentFormat } from '../../../src/file-processors/file-codex-agent.js';
 import type { FileProcessingFrame, TargetContext, PluginSpec, Vfs } from '../../../src/types.js';
 
@@ -120,6 +121,21 @@ describe('fileCodexAgentFormat', () => {
     expect(toml).toContain('sandbox_mode = "workspace-write"');
     // Body is embedded in developer_instructions
     expect(toml).toContain('# Just a plain body');
+  });
+
+  // #271 — fileCodexAgentFormat is the ONLY production path into emitCodexToml, so the escaping
+  // has to hold when the trigger arrives as agent markdown rather than as a bare string.
+  it('an agent body with a literal """ and a backslash still emits parseable TOML (#271, NFR-0001)', () => {
+    const body = 'Match \\d+ in a path C:\\tmp, and fence it:\n"""\nexample\n"""';
+    const content = `---\nname: test\ndescription: desc\nmodel: gpt-5.5-high\nreadonly: false\n---\n\n${body}\n`;
+    const result = fileCodexAgentFormat(makeFrame(content), makeCtx());
+    const toml = result.target_contents as string;
+
+    const parsed = parseToml(toml) as Record<string, unknown>;
+    // The body survives byte-for-byte (the emitter's join adds the newline before the closing fence).
+    expect(parsed.developer_instructions).toBe(`${body}\n`);
+    expect(parsed.name).toBe('test');
+    expect(parsed.sandbox_mode).toBe('workspace-write');
   });
 
   it('body without leading newline is used as-is without slicing (line 36)', () => {

--- a/src/rosettify-plugins/tests/unit/file-processors/file-codex-agent.test.ts
+++ b/src/rosettify-plugins/tests/unit/file-processors/file-codex-agent.test.ts
@@ -125,7 +125,7 @@ describe('fileCodexAgentFormat', () => {
 
   // #271 — fileCodexAgentFormat is the ONLY production path into emitCodexToml, so the escaping
   // has to hold when the trigger arrives as agent markdown rather than as a bare string.
-  it('an agent body with a literal """ and a backslash still emits parseable TOML (#271, NFR-0001)', () => {
+  it('an agent body with a literal """ and a backslash still emits parseable TOML (#271, NFR-0005)', () => {
     const body = 'Match \\d+ in a path C:\\tmp, and fence it:\n"""\nexample\n"""';
     const content = `---\nname: test\ndescription: desc\nmodel: gpt-5.5-high\nreadonly: false\n---\n\n${body}\n`;
     const result = fileCodexAgentFormat(makeFrame(content), makeCtx());

--- a/src/rosettify-plugins/tests/unit/file-processors/file-normalize-copilot-models.test.ts
+++ b/src/rosettify-plugins/tests/unit/file-processors/file-normalize-copilot-models.test.ts
@@ -171,6 +171,18 @@ describe('fileNormalizeCopilotModels — gemini token to display name', () => {
     const result = fileNormalizeCopilotModels(frame, makeCtx());
     expect(result.target_contents as string).toContain('model: Gemini 3.7 Flash');
   });
+
+  // #197 — this token had no Copilot key, so it fell through normalizeCopilot's passthrough and the
+  // raw lowercase id was written into a Copilot plugin as if it were a display name. Cursor mapped
+  // the same literal correctly; this was the only unexplained gap between the two vocabularies.
+  it('gemini-3.5-flash → COPILOT_GEMINI_MAP → Gemini 3.7 Flash, not raw passthrough (#197)', () => {
+    const content = '---\nmodel: gemini-3.5-flash\ntags: []\n---\n# Body\n';
+    const frame = makeFrame(content, 'gemini-3.5-flash');
+    const result = fileNormalizeCopilotModels(frame, makeCtx());
+    expect(result.target_contents as string).toContain('model: Gemini 3.7 Flash');
+    expect(result.target_contents as string).not.toContain('model: gemini-3.5-flash');
+    expect((result.source[0]?.frontmatter as any).model).toBe('Gemini 3.7 Flash');
+  });
 });
 
 // ─── Unknown token passthrough ────────────────────────────────────────────────

--- a/src/rosettify-plugins/tests/unit/serialize/toml.test.ts
+++ b/src/rosettify-plugins/tests/unit/serialize/toml.test.ts
@@ -1,6 +1,24 @@
 // GT-6, PARITY-3 — codex TOML emitter field order and triple-quote
+// NFR-0001 — the emitted document must parse as TOML for ANY body content
 import { describe, it, expect } from 'vitest';
-import { emitCodexToml } from '../../../src/serialize/toml.js';
+import { parse as parseToml } from 'smol-toml';
+import { emitCodexToml, tomlMultilineBodyEscape } from '../../../src/serialize/toml.js';
+
+// Round-trip helper: emit, parse with a strict TOML 1.0.0 parser, hand back the parsed body.
+// Asserting on the parsed VALUE (not just "it parsed") is what catches silent corruption — a raw
+// `\n` in the body parses fine and comes back as a real newline, a different value than the input.
+function roundTripBody(body: string): string {
+  const toml = emitCodexToml({
+    name: 'agent',
+    description: 'desc',
+    developerInstructions: body,
+    sandboxMode: 'workspace-write',
+  });
+  const parsed = parseToml(toml) as Record<string, unknown>;
+  // emitCodexToml lays the block out as `"""\n<body>\n"""`; the newline that precedes the closing
+  // delimiter is part of the value, so strip that one trailing newline to recover the input body.
+  return (parsed.developer_instructions as string).replace(/\n$/, '');
+}
 
 describe('emitCodexToml', () => {
   it('emits correct field order: name, description, developer_instructions, model, model_reasoning_effort, sandbox_mode', () => {
@@ -80,5 +98,84 @@ describe('emitCodexToml', () => {
       sandboxMode: 'read-only',
     });
     expect(toml).toContain('sandbox_mode = "read-only"');
+  });
+});
+
+// #271 — `"""` is the multi-line BASIC form, so escape sequences are processed inside it. Before
+// this, the body went in raw: a literal triple-quote terminated the string early and any backslash
+// was either a hard parse error or a silent value rewrite.
+describe('emitCodexToml — developer_instructions body escaping (#271, NFR-0001)', () => {
+  it('a body containing a literal """ still parses, and round-trips to the same value', () => {
+    const body = 'Fence an example:\n"""\ntoml here\n"""\nDone.';
+    expect(roundTripBody(body)).toBe(body);
+  });
+
+  it('a body containing a backslash still parses, and round-trips to the same value', () => {
+    // `\d` is not a valid TOML escape sequence — unescaped, this is a hard parse error.
+    const body = 'Match with regex \\d+ and a path C:\\Users\\dev';
+    expect(roundTripBody(body)).toBe(body);
+  });
+
+  it('a body containing the two characters \\n round-trips as those two characters, not a newline', () => {
+    // The silent variant of the same defect: unescaped, `\n` is a VALID escape sequence, so the
+    // document parses and quietly yields a real newline — a different value than was written.
+    const body = 'Write \\n to mean a newline.';
+    const parsed = roundTripBody(body);
+    expect(parsed).toBe(body);
+    expect(parsed).not.toContain('\n');
+  });
+
+  it('preserves real newlines and tabs in the body', () => {
+    const body = 'line one\n\tindented\nline three';
+    expect(roundTripBody(body)).toBe(body);
+  });
+
+  it('a body that is nothing but quotes round-trips (long quote run)', () => {
+    const body = '"'.repeat(15);
+    expect(roundTripBody(body)).toBe(body);
+  });
+
+  it('a body ending in a quote round-trips (quote adjacent to the closing fence line)', () => {
+    expect(roundTripBody('he said "hi"')).toBe('he said "hi"');
+    expect(roundTripBody('trailing pair ""')).toBe('trailing pair ""');
+  });
+
+  it('escapes control characters that are illegal inside a multi-line basic string', () => {
+    const body = 'bell:\u0007 bs:\b cr:\r vtab:\u000b ff:\u000c del:\u007f';
+    expect(roundTripBody(body)).toBe(body);
+  });
+});
+
+describe('tomlMultilineBodyEscape', () => {
+  it('leaves prose with no backslash and no long quote run byte-identical', () => {
+    // This is why the 10 committed plugins/core-codex/.codex/agents/*.toml stay unchanged:
+    // runs of one or two quotes are legal unescaped, so ordinary prose is untouched.
+    const body = 'Use the "reviewer" agent — it said ""double"" once.\nTabs\tsurvive.';
+    expect(tomlMultilineBodyEscape(body)).toBe(body);
+  });
+
+  it('escapes every backslash', () => {
+    expect(tomlMultilineBodyEscape('a\\b\\\\c')).toBe('a\\\\b\\\\\\\\c');
+  });
+
+  it('breaks a run of three quotes using the TOML 1.0.0 idiom ""\\"', () => {
+    expect(tomlMultilineBodyEscape('"""')).toBe('""\\"');
+  });
+
+  it('escapes every third quote in a longer run, matching the TOML spec example', () => {
+    // TOML 1.0.0: fifteen quotation marks are written ""\"""\"""\"""\"""\"
+    expect(tomlMultilineBodyEscape('"'.repeat(15))).toBe('""\\"'.repeat(5));
+  });
+
+  it('a quote run of any length 1..20 survives emit + parse unchanged', () => {
+    // The parser is the oracle here rather than a regex over the escaped text: an escaped quote
+    // legitimately sits between two bare ones (a run of 4 emits as ""\""), so "no three quote
+    // characters in a row" is the wrong property — "the document parses to the same value" is the
+    // right one, and it is the property TOML actually requires.
+    for (let n = 1; n <= 20; n += 1) {
+      const body = `pre ${'"'.repeat(n)} post`;
+      expect(roundTripBody(body), `run of ${n} inline`).toBe(body);
+      expect(roundTripBody('"'.repeat(n)), `run of ${n} alone`).toBe('"'.repeat(n));
+    }
   });
 });

--- a/src/rosettify-plugins/tests/unit/serialize/toml.test.ts
+++ b/src/rosettify-plugins/tests/unit/serialize/toml.test.ts
@@ -1,5 +1,5 @@
 // GT-6, PARITY-3 — codex TOML emitter field order and triple-quote
-// NFR-0001 — the emitted document must parse as TOML for ANY body content
+// NFR-0005 — the emitted document must parse as TOML for ANY body content
 import { describe, it, expect } from 'vitest';
 import { parse as parseToml } from 'smol-toml';
 import { emitCodexToml, tomlMultilineBodyEscape } from '../../../src/serialize/toml.js';
@@ -104,7 +104,7 @@ describe('emitCodexToml', () => {
 // #271 — `"""` is the multi-line BASIC form, so escape sequences are processed inside it. Before
 // this, the body went in raw: a literal triple-quote terminated the string early and any backslash
 // was either a hard parse error or a silent value rewrite.
-describe('emitCodexToml — developer_instructions body escaping (#271, NFR-0001)', () => {
+describe('emitCodexToml — developer_instructions body escaping (#271, NFR-0005)', () => {
   it('a body containing a literal """ still parses, and round-trips to the same value', () => {
     const body = 'Fence an example:\n"""\ntoml here\n"""\nDone.';
     expect(roundTripBody(body)).toBe(body);

--- a/src/rosettify-plugins/tests/unit/spec/model-maps.test.ts
+++ b/src/rosettify-plugins/tests/unit/spec/model-maps.test.ts
@@ -193,6 +193,16 @@ describe('normalizeCopilot — new vocabulary entries', () => {
     expect(normalizeCopilot('gemini-3.7-flash-low', COPILOT_VOCABULARY.map)).toBe('Gemini 3.7 Flash');
   });
 
+  // #197 — the superseded Flash token used to have no Copilot key, so normalizeCopilot's passthrough
+  // returned the raw lowercase id while Cursor upgraded the same token. FR-ARCH-0057: "every
+  // `gemini-*` token shall map to `gemini-3.7-flash`".
+  it('maps the superseded gemini-3.5-flash forward to Gemini 3.7 Flash, matching Cursor (#197)', () => {
+    expect(normalizeCopilot('gemini-3.5-flash', COPILOT_VOCABULARY.map)).toBe('Gemini 3.7 Flash');
+    // Not the raw passthrough, and not the superseded display name.
+    expect(normalizeCopilot('gemini-3.5-flash', COPILOT_VOCABULARY.map)).not.toBe('gemini-3.5-flash');
+    expect(normalizeCopilot('gemini-3.5-flash', COPILOT_VOCABULARY.map)).not.toBe('Gemini 3.5 Flash');
+  });
+
   it('maps claude-5-opus-high to Claude Opus 5', () => {
     expect(normalizeCopilot('claude-5-opus-high', COPILOT_VOCABULARY.map)).toBe('Claude Opus 5');
   });
@@ -396,7 +406,7 @@ describe('merged Cursor/Copilot effective map (claude+gpt+gemini, FR-ARCH-0059)'
 
 // ─── Key-disjointness guard: merge order cannot matter (FR-ARCH-0059) ───────────────────────────
 // Cursor merges 5 per-vendor maps (claude/gpt/gemini/grok/composer = 17+33+9+5+1 = 65 keys);
-// Copilot merges 3 (claude/gpt/gemini = 17+33+8 = 58 keys, no grok/composer). Counts grew when the
+// Copilot merges 3 (claude/gpt/gemini = 17+33+9 = 59 keys, no grok/composer). Counts grew when the
 // GPT-5.6 upgrade added the mini family and effort-preserving entries, and the exact-token/Opus-5
 // entries gained a "-high" form. If the per-vendor prefixes ever collided, the spread merge in
 // CURSOR_VOCABULARY/COPILOT_VOCABULARY would silently drop a key and this count would fall below the
@@ -409,9 +419,46 @@ describe('merged vocabulary key disjointness (FR-ARCH-0059)', () => {
     expect(new Set(keys).size).toBe(keys.length);
   });
 
-  it('COPILOT_VOCABULARY.map has exactly 58 keys — the 3 per-vendor source maps never collide', () => {
+  it('COPILOT_VOCABULARY.map has exactly 59 keys — the 3 per-vendor source maps never collide', () => {
     const keys = Object.keys(COPILOT_VOCABULARY.map);
-    expect(keys.length).toBe(58);
+    expect(keys.length).toBe(59);
     expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+// ─── Cursor/Copilot key-set parity guard (#197, FR-ARCH-0057) ───────────────────────────────────
+// The gemini-3.5-flash gap above survived because a key count can only report that a number moved,
+// never WHICH key went missing — and the 9-vs-8 asymmetry was written into the comment beside it as
+// though it were intended. This asserts the two key sets are identical apart from one explicit
+// allowlist, so the next drift names itself. The allowlist encodes the justification already given
+// in prose above COPILOT_VOCABULARY in model-maps.ts: no Copilot-native identifier has been
+// established for Grok or Composer, so those keys are deliberately Cursor-only.
+describe('Cursor/Copilot vocabulary key-set parity (#197, FR-ARCH-0057)', () => {
+  const CURSOR_ONLY_ALLOWLIST = /^(grok|composer)-/;
+
+  it('every Cursor key is a Copilot key too, except the documented grok-*/composer-* exceptions', () => {
+    const unexplained = Object.keys(CURSOR_VOCABULARY.map)
+      .filter((k) => !(k in COPILOT_VOCABULARY.map))
+      .filter((k) => !CURSOR_ONLY_ALLOWLIST.test(k));
+    expect(unexplained).toEqual([]);
+  });
+
+  it('Copilot carries no key Cursor lacks — Cursor is the superset', () => {
+    const copilotOnly = Object.keys(COPILOT_VOCABULARY.map).filter(
+      (k) => !(k in CURSOR_VOCABULARY.map),
+    );
+    expect(copilotOnly).toEqual([]);
+  });
+
+  it('the allowlist is not vacuous — grok/composer keys really are Cursor-only', () => {
+    // Guards the guard: if Copilot ever gains these, the allowlist must be narrowed rather than
+    // left as a permanent blanket exemption.
+    const allowlisted = Object.keys(CURSOR_VOCABULARY.map).filter((k) =>
+      CURSOR_ONLY_ALLOWLIST.test(k),
+    );
+    expect(allowlisted.length).toBeGreaterThan(0);
+    for (const key of allowlisted) {
+      expect(key in COPILOT_VOCABULARY.map, `${key} unexpectedly present in Copilot`).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Twelve low-risk fixes across five components, each reviewed against the code before implementation and validated with a test that fails before the fix.

| # | fix |
|---|---|
| #207 | `doc_cache.get_all_docs_async` now honors `ROSETTA_TOOL_TIMEOUT`; default unchanged |
| #209 | Redis migration lock release fenced by a per-run token, so a run that lost the lock cannot delete another pod's |
| #196 | MCP client name/version cached per session instead of in module globals; failed resolutions are not cached |
| #305 | Non-force `parse` uses one dataset list call instead of two |
| #194 | `_cleanup_duplicates` no longer deletes documents without `original_path`, matching its docstring |
| #297 | Environment label detected from URL keywords, so a default install reports `local` |
| #178 | Agent `model:` fields normalized to canonical Anthropic model ids |
| #197 | Copilot vocabulary gains the missing `gemini-3.5-flash` key |
| #271 | Codex TOML `developer_instructions` body escaped, so a body containing `"""` or a backslash still parses |
| #198 | Explicit least-privilege `permissions:` on three PyPI publish workflows |
| #301 | Helm chart `appVersion` synced to the server version, with a CI drift guard and bump-script wiring |
| #223 | Unimplemented `debounceMs` throttle variant removed from the type |

## Notes for reviewers

Three issues turned out to differ from their own text, and the implementation follows the code rather than the report:

- **#197** — the issue asks for `Gemini 3.5 Flash`. FR-ARCH-0057 (Approved) requires `Gemini 3.7 Flash`; implementing the issue verbatim would pin a superseded model on Copilot while Cursor upgrades it.
- **#178** — the issue names `claude-opus-4-8` as canonical. `docs/schemas/agent.md` says `claude-opus-5`. Scope is also wider than filed: 23 files, because the `~profile-lightweight-only~` agents ship too.
- **#209** — the lock never guaranteed "exactly once". `docs/MCP-ARCHITECTURE.md` and the web mirror said it did; both are corrected. What makes multi-replica deploys safe is idempotent migrations plus the version re-read under the lock.

**#297 changes a displayed value.** `ims-dev.example.com` now reports `dev` rather than `ims-dev`. The label is display-only — nothing branches on it. Substring matching also fires on incidental hits (`advantest` → `test`), which is inherent to the chosen rule and pinned by test.

**#301 publishes on merge.** The chart `version` bump from `0.4.1` to `0.4.2` is required, not incidental: the publish workflow has no version-exists guard, so an `appVersion`-only change would overwrite the published `0.4.1` in place.

**#271 and #197 are latent.** No instruction file today contains a `"""`, a backslash in an agent body, or a normalizable `gemini-3.5-flash` token, so both are hardening. Regenerating all 14 plugin trees with the local generator produces zero diff, so the three generator/instruction changes are jointly output-neutral.

## Validation

- `rosetta-mcp-server` 355 passed · `rosetta-cli` 101 passed · `hooks` 1257 passed · `rosettify-plugins` 761 passed
- `src/validate-types.sh` passed
- Helm `lint`, `template`, `unittest` pass; the #301 drift guard was verified to exit 1 on the pre-fix state and 0 after
- Not covered: `verify_mcp.py` needs a live server, so the three MCP fixes are unit-validated only

## Also included

Two comments recording an accepted limitation, closing no issue. Every list path in `parse` and `cleanup-dataset` reads one page, bounded by `RAGFLOW_PAGE_SIZE` (default 1000). For `cleanup-dataset` this matters more, because it resolves its target from `--dataset` and so can run against any dataset: on a larger one it deletes the first page and reports success. Documented rather than changed — the instruction set is not expected to approach the cap, and both commands serve the optional MCP publishing pipeline rather than plugin delivery.

## Deliberately not included

#193, #199, #264 and #269 were reviewed and need no code — #199 and #264 are already fixed, #193's premise does not hold, and #269's two sides are intentional. #172, #312, #261, #303, #288, #302, #255, #222, #210, #173 and #224 need human decisions and stay open.

Closes #207
Closes #209
Closes #196
Closes #305
Closes #194
Closes #297
Closes #178
Closes #197
Closes #271
Closes #198
Closes #301
Closes #223
