### PR TITLE
fix(hooks): avoid quadratic dangerous-action matching family-wide

### DIFF
--- a/src/hooks/src/hooks/dangerous-actions/patterns.ts
+++ b/src/hooks/src/hooks/dangerous-actions/patterns.ts
@@ -55,12 +55,65 @@ const SQL_TRUNCATE_RE = /\btruncate\s+(?:table\s+)?\w+/i;
 //       known gap on a `reconsider`-tier guard; see the "known limitation" tests.
 //
 // Both directions are pinned by characterization tests so a future change is noticed.
-const SQL_DELETE_NO_WHERE_RE   = /\bdelete\s+from\b(?![^;]*\bwhere\b)/i;
-const SQL_UPDATE_NO_WHERE_RE   = /\bupdate\s+\S+\s+set\b(?![^;]*\bwhere\b)/i;
+//
+// SCALING NOTE — this family is the INVERSE of the suffix-window case used by the
+// matchers further down. The WHERE guard is a NEGATIVE (not-exists) lookahead, so it
+// is ANTI-monotone: a later candidate in the same statement sees a strict SUFFIX of
+// the earlier one's window, and "no WHERE in a suffix" is IMPLIED by "no WHERE in the
+// whole window" — never the other way round. The BEST candidate is therefore the LAST
+// one in the statement, not the first, and anchoring to the first candidate (the shape
+// that is correct for every other matcher here) would be a FALSE NEGATIVE bug.
+//
+// So instead of a segment prefix, a candidate is discarded when another candidate
+// follows it inside the same statement: `(?![^;]*?<keyword>)`. That check is
+// self-limiting — it stops at the NEXT candidate rather than scanning to the end of
+// the statement — so the overlapping-rescan cost disappears while the surviving
+// candidate is exactly the last one, which is the one with the widest WHERE window.
+// The lazy `*?` is language-identical to a greedy `*` here (both are existence checks)
+// and is used only so the scan stops at the first hit instead of backtracking from the
+// end of the statement.
+//
+// FAILURE MODE if this is ever changed: bounding the WHERE lookahead (to a line, or to
+// a fixed distance) makes the not-exists guard succeed too often and produces FALSE
+// POSITIVES; dropping the "no later candidate" guard restores the quadratic rescan;
+// replacing it with a first-candidate prefix produces FALSE NEGATIVES.
+// `;` is the ONLY boundary here — `[^;]*` crosses CR/LF deliberately.
+const SQL_DELETE_FROM_KEYWORD = String.raw`\bdelete\s+from\b`;
+const SQL_DELETE_NO_WHERE_RE   = new RegExp(
+  SQL_DELETE_FROM_KEYWORD +
+  String.raw`(?![^;]*?${SQL_DELETE_FROM_KEYWORD})(?![^;]*\bwhere\b)`, 'i');
+// Same anti-monotone / last-candidate treatment as SQL_DELETE_NO_WHERE_RE above.
+// One extra subtlety: this keyword's table operand is `\S+`, which CAN swallow a `;`
+// (`UPDATE a;b SET …`). The "no later candidate" guard therefore uses a `;`-free
+// variant of the keyword (`[^;\s]+`), so the candidate it hands off to is guaranteed to
+// end inside the SAME statement. Using plain `\S+` there would let the guard discard a
+// candidate in favour of one whose WHERE window starts past the `;` — a FALSE NEGATIVE
+// (`update a set x update b;c set y where z` is the witness: the straddling candidate's
+// own WHERE window starts after the `;`, so the guard would hand off to a candidate that
+// cannot vouch for the first one's statement).
+const SQL_UPDATE_SET_KEYWORD          = String.raw`\bupdate\s+\S+\s+set\b`;
+const SQL_UPDATE_SET_KEYWORD_IN_STMT  = String.raw`\bupdate\s+[^;\s]+\s+set\b`;
+const SQL_UPDATE_NO_WHERE_RE   = new RegExp(
+  SQL_UPDATE_SET_KEYWORD +
+  String.raw`(?![^;]*?${SQL_UPDATE_SET_KEYWORD_IN_STMT})(?![^;]*\bwhere\b)`, 'i');
 const SQL_DROP_INDEX_VIEW_RE   = /\bdrop\s+(?:index|view)\b/i;
 // ALTER … DROP COLUMN within one statement; `[^;]*` keeps the DROP bound to its
 // own ALTER TABLE (so an ADD COLUMN in the same statement is not mis-flagged).
-const SQL_ALTER_DROP_COLUMN_RE = /\balter\s+table\b[^;]*\bdrop\s+column\b/i;
+//
+// Start candidate discovery at a statement boundary and stop the prefix at the FIRST
+// `ALTER TABLE` in that statement. `;` is the ONLY boundary here — `[^;]*` crosses
+// CR/LF deliberately, so line breaks must NOT be added to the class. The DROP COLUMN
+// search is an unbounded existential scan to the next `;`, so every later ALTER TABLE
+// in the same statement sees a strict SUFFIX of the first one's window: whatever a
+// later candidate can see, the first candidate can see too.
+// FAILURE MODE if this is ever changed: bounding that scan (to a line, or to a fixed
+// distance) breaks the suffix relation and turns this into FALSE NEGATIVES for a DROP
+// COLUMN that sits far from its ALTER TABLE.
+const SQL_ALTER_TABLE_KEYWORD  = String.raw`\balter\s+table\b`;
+const SQL_ALTER_TABLE_STATEMENT =
+  String.raw`(?:^|;)(?:(?!${SQL_ALTER_TABLE_KEYWORD})[^;])*${SQL_ALTER_TABLE_KEYWORD}`;
+const SQL_ALTER_DROP_COLUMN_RE = new RegExp(
+  SQL_ALTER_TABLE_STATEMENT + String.raw`[^;]*\bdrop\s+column\b`, 'i');
 
 // `rm` recursive + force detection. GNU getopt permutes options past operands,
 // so the recursive flag (-r/-R/--recursive) and the force flag (-f/--force) may
@@ -76,6 +129,12 @@ const RM_RF_GUARD     = RM_RECURSIVE_LA + RM_FORCE_LA;
 // A root operand: a standalone `/` (or `/*`), i.e. a slash followed by space/end/`*`.
 const RM_ROOT_TARGET  = String.raw`.*\s\/(?:\*|\s|$)`;
 const RM_HOME_TARGET  = String.raw`.*\s(?:~(?:\/|\s|$)|\$HOME\b)`;
+// Both flag lookaheads and both target scans above use unbounded `.`-windows that run
+// to the end of the line, so every later `rm` on the same line sees a strict SUFFIX of
+// the first one's window — see `firstOnLine` below for the invariant and its failure
+// mode. `rm` is a single token, so no gap can straddle a line break and no cross-line
+// alternative is needed. NOTE: `;`, `&&` and `|` are NOT boundaries for these windows
+// and never were — `rm -r a; -f b` matches today and must keep matching.
 
 // `git push` force detection. Two independent force mechanisms:
 //   (a) an explicit force flag — `-f` or `--force` — but NOT the safer
@@ -93,6 +152,47 @@ const GIT_FORCE_FLAG_LA = String.raw`(?=(?:\s+\S+)*\s+(?:-f\b|--force(?!-with-le
 // that repository — so a bare `git push +main` (where `+main` IS the repository
 // argument, not a refspec) is left alone and handled separately.
 const GIT_FORCE_REFSPEC_LA = String.raw`(?=(?:\s+-\S+)*\s+(?!-)(?!['"]?\+)\S+(?:\s+\S+)*\s+['"]?\+\S)`;
+
+// SCALING — `git push` needs a DIFFERENT treatment from every other matcher here, and
+// the difference is worth spelling out because the obvious fix is wrong.
+//
+// 1. There is NO segment boundary. Both lookaheads are built out of `\s`, which matches
+//    CR and LF, and neither is bounded by `;`, `&&` or `|`. The window of a candidate is
+//    therefore the WHOLE REST OF THE INPUT — `git push a; echo --force` matches today
+//    and must keep matching. That also means there is no cross-line case to carve out:
+//    a line break is just another `\s`, so `^` (this RegExp has no `m` flag) is the only
+//    segment start there is.
+//
+// 2. The two lookaheads do NOT share a monotonicity property, so they cannot share one
+//    prefix.
+//    * The FLAG lookahead is a plain existential — "some later whitespace-delimited
+//      token starts with -f / --force" — so a later candidate's window is a strict
+//      SUFFIX of an earlier candidate's window and the FIRST candidate sees everything.
+//      The one precondition is that the candidate is followed by whitespace: both
+//      lookaheads open with `\s+`, so a candidate that is not (e.g. `git push;…`) can
+//      never match and must be skipped rather than anchored to — otherwise
+//      `git push;git push --force` becomes a FALSE NEGATIVE.
+//    * The REFSPEC lookahead is NOT existential. It pins the repository operand to the
+//      FIRST non-flag token after `git push` and then requires `(?!['"]?\+)` of it. That
+//      guard can fail for an early candidate and hold for a later one, so the suffix
+//      relation breaks: `git push +foo git push origin +main` matches today, but only at
+//      the SECOND candidate. Anchoring both branches to one shared first candidate
+//      silently drops it.
+//
+// So each branch gets its own prefix, each anchored to the first candidate that its own
+// branch could possibly satisfy. Among refspec-viable candidates the lookahead IS
+// monotone again — the repository operand of an earlier viable candidate sits at or
+// before that of a later one, and the `+`-refspec witness lies after both — so the first
+// viable candidate is sufficient.
+//
+// FAILURE MODE if this is ever changed: merging the two prefixes, dropping `(?=\s)` from
+// the flag head, dropping the `(?!['"]?\+)` guard from the refspec head, or bounding
+// either lookahead to a scan distance or a shell separator all produce FALSE NEGATIVES.
+// Each of those four is pinned by a test below.
+const GIT_PUSH_FLAG_HEAD    = String.raw`${GIT_PUSH}(?=\s)`;
+const GIT_PUSH_REFSPEC_HEAD = String.raw`${GIT_PUSH}(?=(?:\s+-\S+)*\s+(?!-)(?!['"]?\+)\S)`;
+const firstInInput = (head: string): string =>
+  String.raw`^(?:(?!${head})[\s\S])*${head}`;
 
 // `git branch` force-delete detection. `-D` is shorthand for `--delete --force`.
 // Git also accepts delete + force as separate short/long flags, in either order,
@@ -118,27 +218,109 @@ const GIT_BRANCH = String.raw`(?:${GIT_BRANCH_SEGMENT_PREFIX}${GIT_BRANCH_LOCAL}
 const GIT_BRANCH_DELETE_LA = String.raw`(?=[^;&|\r\n]*(?:\s--delete\b|\s-[a-zA-Z]*[dD][a-zA-Z]*\b))`;
 const GIT_BRANCH_FORCE_LA = String.raw`(?=[^;&|\r\n]*(?:\s--force\b|\s-[a-zA-Z]*[fD][a-zA-Z]*\b))`;
 
+// ---------------------------------------------------------------------------
+// Segment anchoring for `.`-window matchers.
+//
+// JS `.` (no `s` flag) matches every character EXCEPT these four, so any `.`-based
+// scan or lookahead window ends exactly at the next one of them. They are therefore
+// the ONLY segment boundaries for the matchers below. `;`, `&&` and `|` are
+// deliberately NOT boundaries here: the pre-existing matchers never treated them as
+// such, and narrowing the window to shell command separators would be a policy
+// change (new false negatives), not the matcher-shape change intended here.
+// U+2028/U+2029 must stay in the class: omitting them lets the prefix run past a
+// boundary that `.` cannot cross, which reintroduces false negatives.
+const LINE_BREAK_CLASS = String.raw`\r\n\u2028\u2029`;
+const LINE_START       = String.raw`(?:^|[${LINE_BREAK_CLASS}])`;
+// Whitespace that is NOT a line break — used to keep a multi-token keyword line-local.
+const INLINE_SPACE     = String.raw`[^\S${LINE_BREAK_CLASS}]`;
+
+/**
+ * Start candidate discovery at a line boundary and stop the prefix at the FIRST
+ * line-local occurrence of `keyword` on that line.
+ *
+ * INVARIANT (why this is sound): every predicate applied after the keyword is an
+ * EXISTENTIAL check over an UNBOUNDED `.`-window that runs to the end of the line.
+ * A later candidate on the same line therefore sees a window that is a strict SUFFIX
+ * of the first candidate's window, so anything a later candidate can see the first
+ * candidate can see too. Trying only the first candidate per line loses nothing.
+ *
+ * FAILURE MODE if this is ever changed: bounding any of those lookaheads to a fixed
+ * scan distance (or to `;`/`&&`/`|`) destroys the suffix-window relation and turns
+ * this optimization into FALSE NEGATIVES — a qualifying flag that sits far from the
+ * keyword, or past a `;`, would stop being seen. Keep the windows unbounded.
+ */
+const firstOnLine = (keyword: string): string =>
+  String.raw`${LINE_START}(?:(?!${keyword}).)*${keyword}`;
+
+// `aws s3 rm --recursive`. `--recursive` is found by an unbounded `.`-window, so the
+// suffix-window invariant above applies to the two `aws`/`s3`/`rm` gaps.
+// CR/LF/U+2028/U+2029 must remain segment boundaries: this RegExp has no `m` flag, so
+// `^` only matches the input start; without the explicit line-separator class the
+// prefix could not begin after a line boundary.
+const AWS_S3_RM_LOCAL = String.raw`\baws${INLINE_SPACE}+s3${INLINE_SPACE}+rm\b`;
+// Preserve the prior `\s+` behavior when a gap straddles a line break (either gap).
+// Such candidates necessarily cross a boundary, so their windows stay bounded and
+// cannot recreate the overlapping rescan.
+const AWS_S3_RM_CROSS_LINE = String.raw`(?:\baws${INLINE_SPACE}*[${LINE_BREAK_CLASS}]\s*s3\s+rm\b|\baws${INLINE_SPACE}+s3${INLINE_SPACE}*[${LINE_BREAK_CLASS}]\s*rm\b)`;
+const AWS_S3_RM = String.raw`(?:${firstOnLine(AWS_S3_RM_LOCAL)}|${AWS_S3_RM_CROSS_LINE})`;
+
+// `kubectl delete --all`. `--all` is found by an unbounded `.`-window; same
+// suffix-window invariant and same cross-line carve-out as AWS_S3_RM above.
+const KUBECTL_DELETE_LOCAL = String.raw`\bkubectl${INLINE_SPACE}+delete\b`;
+const KUBECTL_DELETE_CROSS_LINE = String.raw`\bkubectl${INLINE_SPACE}*[${LINE_BREAK_CLASS}]\s*delete\b`;
+const KUBECTL_DELETE = String.raw`(?:${firstOnLine(KUBECTL_DELETE_LOCAL)}|${KUBECTL_DELETE_CROSS_LINE})`;
+
+// `dd of=/dev/…`. `of=/dev/` is found by an unbounded `.`-window; same suffix-window
+// invariant as above. `dd` is a single token with no internal whitespace, so — unlike
+// `aws s3 rm` or `kubectl delete` — there is no gap that could straddle a line break
+// and therefore no cross-line alternative to preserve.
+const DD_LOCAL = String.raw`\bdd\b`;
+const DD = firstOnLine(DD_LOCAL);
+
+// `curl … | sh`. The pipe-to-shell tail is found by an unbounded `.`-window, so the
+// same suffix-window invariant applies. The single `\s` that the original required
+// right after `curl` is split into its line-local half (which keeps the candidate on
+// one line) and its line-break half (the cross-line alternative); the two halves are
+// disjoint and their union is exactly `\s`, so the accepted keyword set is unchanged.
+const CURL_LOCAL = String.raw`\bcurl${INLINE_SPACE}`;
+const CURL_CROSS_LINE = String.raw`\bcurl[${LINE_BREAK_CLASS}]`;
+const CURL = String.raw`(?:${firstOnLine(CURL_LOCAL)}|${CURL_CROSS_LINE})`;
+
+const RM = firstOnLine(String.raw`\brm\b`);
+
+// `psql … DROP TABLE`. Unlike the matchers above, this window is bounded by a QUOTE
+// (`"` or `'`), not by a line break — `[^"']*` happily crosses CR/LF — so the segment
+// here is the quote-free run, and quotes are its only boundaries. `psql` is a single
+// token, so there is no gap to straddle and no cross-line alternative is needed.
+// Same suffix-window invariant: the DROP search is an unbounded existential scan to
+// the next quote, so a later `psql` in the same quote-free run sees a strict suffix of
+// the first one's window. Bounding that scan (e.g. to a line) would produce FALSE
+// NEGATIVES for a DROP that sits far from the `psql` token.
+const PSQL_SEGMENT = String.raw`(?:^|["'])(?:(?!\bpsql\b)[^"'])*\bpsql\b`;
+
 export const DANGEROUS_BASH: readonly DangerPattern[] = [
-  { id: 'rm-rf-root',          re: new RegExp(String.raw`\brm\b` + RM_RF_GUARD + RM_ROOT_TARGET),              label: 'rm -rf /',              reason: REASON.FILE_DELETION,         policy: 'reconsider' },
-  { id: 'rm-rf-home',          re: new RegExp(String.raw`\brm\b` + RM_RF_GUARD + RM_HOME_TARGET),              label: 'rm -rf $HOME',          reason: REASON.FILE_DELETION,         policy: 'reconsider' },
-  { id: 'rm-rf-recursive',     re: new RegExp(String.raw`\brm\b` + RM_RF_GUARD),                               label: 'rm -rf (generic)',      reason: REASON.FILE_DELETION,         policy: 'reconsider' },
+  { id: 'rm-rf-root',          re: new RegExp(RM + RM_RF_GUARD + RM_ROOT_TARGET),                              label: 'rm -rf /',              reason: REASON.FILE_DELETION,         policy: 'reconsider' },
+  { id: 'rm-rf-home',          re: new RegExp(RM + RM_RF_GUARD + RM_HOME_TARGET),                              label: 'rm -rf $HOME',          reason: REASON.FILE_DELETION,         policy: 'reconsider' },
+  { id: 'rm-rf-recursive',     re: new RegExp(RM + RM_RF_GUARD),                                               label: 'rm -rf (generic)',      reason: REASON.FILE_DELETION,         policy: 'reconsider' },
   { id: 'sql-drop-table',      re: SQL_DROP_RE,                                                                label: 'DDL DROP',              reason: REASON.SCHEMA_MODIFICATION,   policy: 'reconsider' },
   { id: 'sql-truncate',        re: SQL_TRUNCATE_RE,                                                            label: 'TRUNCATE TABLE',        reason: REASON.DATA_MANIPULATION,     policy: 'reconsider' },
   { id: 'sql-delete-no-where', re: SQL_DELETE_NO_WHERE_RE,                                                     label: 'DELETE without WHERE',  reason: REASON.DATA_MANIPULATION,     policy: 'reconsider' },
   { id: 'sql-update-no-where', re: SQL_UPDATE_NO_WHERE_RE,                                                     label: 'UPDATE without WHERE',  reason: REASON.DATA_MANIPULATION,     policy: 'reconsider' },
   { id: 'sql-drop-index-view', re: SQL_DROP_INDEX_VIEW_RE,                                                     label: 'DROP INDEX/VIEW',       reason: REASON.SCHEMA_MODIFICATION,   policy: 'reconsider' },
   { id: 'sql-alter-drop-col',  re: SQL_ALTER_DROP_COLUMN_RE,                                                   label: 'ALTER DROP COLUMN',     reason: REASON.SCHEMA_MODIFICATION,   policy: 'reconsider' },
-  { id: 'git-force-push',      re: new RegExp(GIT_PUSH + `(?:${GIT_FORCE_FLAG_LA}|${GIT_FORCE_REFSPEC_LA})`),  label: 'git push --force',      reason: REASON.GIT_HISTORY_REWRITE,   policy: 'reconsider' },
+  { id: 'git-force-push',      re: new RegExp(
+      `${firstInInput(GIT_PUSH_FLAG_HEAD)}${GIT_FORCE_FLAG_LA}` +
+      `|${firstInInput(GIT_PUSH_REFSPEC_HEAD)}${GIT_FORCE_REFSPEC_LA}`),               label: 'git push --force',      reason: REASON.GIT_HISTORY_REWRITE,   policy: 'reconsider' },
   { id: 'git-reset-hard',      re: /\bgit\s+reset\s+--hard\b/,                                                 label: 'git reset --hard',      reason: REASON.GIT_HISTORY_REWRITE,   policy: 'reconsider' },
   { id: 'git-clean-force',     re: /\bgit\s+clean\s+-[a-z]*[fd]/,                                              label: 'git clean -fd',         reason: REASON.FILE_DELETION,         policy: 'reconsider' },
   { id: 'git-branch-delete',   re: new RegExp(GIT_BRANCH + GIT_BRANCH_DELETE_LA + GIT_BRANCH_FORCE_LA),         label: 'git branch -D',         reason: REASON.GIT_HISTORY_REWRITE,   policy: 'reconsider' },
-  { id: 'aws-s3-rm-recursive', re: /\baws\s+s3\s+rm\b.*--recursive\b/,                                         label: 'aws s3 rm --recursive', reason: REASON.FILE_DELETION,         policy: 'reconsider' },
-  { id: 'kubectl-delete-prod', re: /\bkubectl\s+delete\b.*--all\b/,                                            label: 'kubectl mass delete',   reason: REASON.INFRA_OPERATION,       policy: 'reconsider' },
-  { id: 'dropdb',              re: /\b(?:dropdb\b|psql\b[^"']*\bdrop\s+(?:table|database|schema)\b)/i,         label: 'DB drop CLI',           reason: REASON.SCHEMA_MODIFICATION,   policy: 'reconsider' },
+  { id: 'aws-s3-rm-recursive', re: new RegExp(AWS_S3_RM + String.raw`.*--recursive\b`),                        label: 'aws s3 rm --recursive', reason: REASON.FILE_DELETION,         policy: 'reconsider' },
+  { id: 'kubectl-delete-prod', re: new RegExp(KUBECTL_DELETE + String.raw`.*--all\b`),                          label: 'kubectl mass delete',   reason: REASON.INFRA_OPERATION,       policy: 'reconsider' },
+  { id: 'dropdb',              re: new RegExp(String.raw`(?:\bdropdb\b|${PSQL_SEGMENT}[^"']*\bdrop\s+(?:table|database|schema)\b)`, 'i'), label: 'DB drop CLI', reason: REASON.SCHEMA_MODIFICATION, policy: 'reconsider' },
   { id: 'mkfs',                re: /\bmkfs(?:\.\w+)?\b/,                                                       label: 'filesystem format',     reason: REASON.DEVICE_OPERATION,      policy: 'reconsider' },
-  { id: 'dd-of-dev',           re: /\bdd\b.*\bof=\/dev\//,                                                     label: 'dd to device',          reason: REASON.DEVICE_OPERATION,      policy: 'reconsider' },
+  { id: 'dd-of-dev',           re: new RegExp(DD + String.raw`.*\bof=\/dev\/`),                                label: 'dd to device',          reason: REASON.DEVICE_OPERATION,      policy: 'reconsider' },
   { id: 'chmod-777-recursive', re: /\bchmod\s+-R\s+0?777\b/,                                                   label: 'chmod -R 777',          reason: REASON.PERMISSION_CHANGE,     policy: 'reconsider' },
-  { id: 'curl-pipe-shell',     re: /\bcurl\s.*\s\|\s*(?:sh|bash)\b/,                                           label: 'curl | sh',             reason: REASON.REMOTE_CODE_EXECUTION, policy: 'reconsider' },
+  { id: 'curl-pipe-shell',     re: new RegExp(CURL + String.raw`.*\s\|\s*(?:sh|bash)\b`),                      label: 'curl | sh',             reason: REASON.REMOTE_CODE_EXECUTION, policy: 'reconsider' },
 ] as const;
 
 // Irreversible key/credential files. These are NOT about secrecy (Rosetta does not
@@ -147,6 +329,18 @@ export const DANGEROUS_BASH: readonly DangerPattern[] = [
 // a credential store), the same data-loss class as `rm -rf` or `git reset --hard`.
 // Hence policy 'advise': a non-blocking heads-up, never a block. Normal working files
 // like `.env` are intentionally NOT listed — writing them is ordinary development.
+// `~/.gnupg/*.key`. The `.key` search is an unbounded `.`-window, so this entry has
+// the same suffix-window invariant as the command matchers above: a later `/.gnupg/`
+// on the same line sees a strict suffix of the first one's window. Discovery is
+// anchored to the first `/.gnupg/` per line; the literal `private-keys-v1.d/`
+// alternative needs no anchoring. `/.gnupg/` has no internal whitespace, so no gap can
+// straddle a line break and no cross-line alternative is needed.
+// FAILURE MODE if this is ever changed: bounding the `.key` scan produces FALSE
+// NEGATIVES for a key file nested deeper under `.gnupg/`.
+const GNUPG_DIR = String.raw`\/\.gnupg\/`;
+const GPG_PRIVATE_RE = new RegExp(
+  String.raw`(?:${firstOnLine(GNUPG_DIR)}.*\.key|${GNUPG_DIR}private-keys-v1\.d\/)`);
+
 export const DANGEROUS_PATHS: readonly DangerPattern[] = [
   { id: 'ssh-private-key',  re: /^(?:id_rsa|id_ed25519|id_ecdsa|id_dsa)$/,                        label: 'SSH private key',  reason: REASON.CREDENTIAL_OVERWRITE, policy: 'advise' },
   { id: 'aws-credentials',  re: /\/\.aws\/(?:credentials|config)/,                                label: 'AWS credentials',  reason: REASON.CREDENTIAL_OVERWRITE, policy: 'advise' },
@@ -154,7 +348,7 @@ export const DANGEROUS_PATHS: readonly DangerPattern[] = [
   { id: 'kube-config',      re: /\/\.kube\/config$/,                                              label: 'kubeconfig',       reason: REASON.CREDENTIAL_OVERWRITE, policy: 'advise' },
   { id: 'netrc',            re: /^[._]netrc$/,                                                    label: 'netrc',            reason: REASON.CREDENTIAL_OVERWRITE, policy: 'advise' },
   { id: 'pgpass',           re: /^\.pgpass$/,                                                     label: 'Postgres .pgpass', reason: REASON.CREDENTIAL_OVERWRITE, policy: 'advise' },
-  { id: 'gpg-private',      re: /\/\.gnupg\/(?:.*\.key|private-keys-v1\.d\/)/,                    label: 'GPG private key',  reason: REASON.CREDENTIAL_OVERWRITE, policy: 'advise' },
+  { id: 'gpg-private',      re: GPG_PRIVATE_RE,                                                   label: 'GPG private key',  reason: REASON.CREDENTIAL_OVERWRITE, policy: 'advise' },
 ] as const;
 
 export const DANGEROUS_CONTENT: readonly DangerPattern[] = [

--- a/src/hooks/tests/dangerous-actions-matcher-scaling.test.ts
+++ b/src/hooks/tests/dangerous-actions-matcher-scaling.test.ts
@@ -1,0 +1,587 @@
+import { performance } from 'node:perf_hooks';
+import { describe, expect, test } from 'vitest';
+import { DANGEROUS_BASH, DANGEROUS_PATHS } from '../src/hooks/dangerous-actions/patterns';
+import { evaluateDangerous } from '../src/hooks/dangerous-actions/evaluate';
+import type { HookContext } from '../src/runtime/types';
+
+/**
+ * Scaling-fix characterization suite for the dangerous-action matchers that shared the
+ * unbounded-rescan defect fixed for `git-branch-delete` in #320 (see that pattern's own
+ * suite in git-branch-delete.test.ts).
+ *
+ * EVERY expectation here was derived from the PRE-CHANGE matcher and is pinned so the
+ * refactor cannot widen or narrow detection. Note the separator sets DIFFER per family
+ * and are deliberately preserved:
+ *   - rm / aws / kubectl / dd / curl: the window is bounded by LINE TERMINATORS only,
+ *     so `;`, `&&` and `|` do NOT isolate and must keep not isolating.
+ *   - dropdb: the window is bounded by QUOTES only.
+ *   - sql-*: the window is bounded by `;` only; CR/LF do NOT isolate.
+ *   - git-force-push: NOTHING isolates — the window is the whole input.
+ */
+
+const patternById = (id: string): RegExp =>
+  DANGEROUS_BASH.find((pattern) => pattern.id === id)!.re;
+
+const bashCtx = (command: string): HookContext => ({
+  ide: 'claude-code',
+  event: 'PreToolUse',
+  toolKind: 'bash',
+  toolName: 'Bash',
+  filePath: '',
+  cwd: '/proj',
+  sessionId: null,
+  toolInput: { command },
+});
+
+// PreToolUse runs before every Bash tool call, so a pathological matcher delays every
+// command. Budget matches the one #320 introduced for git-branch-delete.
+const writeCtx = (filePath: string): HookContext => ({
+  ide: 'claude-code',
+  event: 'PreToolUse',
+  toolKind: 'write',
+  toolName: 'Write',
+  filePath,
+  cwd: '/proj',
+  sessionId: null,
+  toolInput: { file_path: filePath, content: 'x' },
+});
+
+const LATENCY_BUDGET_MS = 250;
+const ADVERSARIAL_REPEATS = 16000;
+
+describe('rm-rf-recursive matcher shape', () => {
+  test.each([
+    ["later candidate in same segment", "rm a pad pad pad pad pad pad rm -rf b", true],
+    ["flag on next line via trailing \\s (LF)", "rm -r a\n-f b", true],
+    ["flag on next line via trailing \\s (CRLF)", "rm -r a\r\n-f b", false],
+    ["flag on next line via trailing \\s (CR)", "rm -r a\r-f b", true],
+    ["flag two tokens past LF", "rm -r a\nx -f b", false],
+    ["flag two tokens past CRLF", "rm -r a\r\nx -f b", false],
+    ["flag past U+2028", "rm -r a\u2028x -f b", false],
+    ["flag past U+2029", "rm -r a\u2029x -f b", false],
+    ["flags combine across ;", "rm -r a; -f b", true],
+    ["flags combine across &&", "rm -r a && -f b", true],
+    ["flags combine across |", "rm -r a | -f b", true],
+    ["far apart flags", "rm -r a pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad -f", true],
+    ["second line dangerous", "rm a\nrm -rf b", true],
+    ["second line dangerous after U+2028", "rm a\u2028rm -rf b", true],
+    ["safe", "rm a b", false],
+  ] as const)('%s', (_name, command, expected) => {
+    expect(patternById('rm-rf-recursive').test(command)).toBe(expected);
+  });
+
+  test('is reconsidered through the production evaluate path', () => {
+    const result = evaluateDangerous(bashCtx("rm a pad pad pad pad pad pad rm -rf b"));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain('[rm-rf-recursive]');
+  });
+
+  // Separator-free near miss: 16000 candidates, none of which qualifies. Pre-change this
+  // cost 1732 ms through this same path; post-change 3.0 ms.
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx("rm a"));
+    }
+
+    const command = "rm a ".repeat(ADVERSARIAL_REPEATS);
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});
+
+describe('rm-rf-root matcher shape', () => {
+  test.each([
+    ["later candidate", "rm a pad pad pad pad pad pad rm -rf /", true],
+    ["second line dangerous", "rm a\nrm -rf /", true],
+    ["second line dangerous after U+2028", "rm a\u2028rm -rf /", true],
+    ["flags combine across ;", "rm -r a; -f /", true],
+    ["root target on next line", "rm -rf a\n/ x", true],
+    ["safe", "rm -rf ./a", false],
+  ] as const)('%s', (_name, command, expected) => {
+    expect(patternById('rm-rf-root').test(command)).toBe(expected);
+  });
+
+  test('is reconsidered through the production evaluate path', () => {
+    const result = evaluateDangerous(bashCtx("rm a pad pad pad pad pad pad rm -rf /"));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain('[rm-rf-root]');
+  });
+
+  // Separator-free near miss: 16000 candidates, none of which qualifies. Pre-change this
+  // cost 1738 ms through this same path; post-change 2.6 ms.
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx("rm a"));
+    }
+
+    const command = "rm a ".repeat(ADVERSARIAL_REPEATS);
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});
+
+describe('rm-rf-home matcher shape', () => {
+  test.each([
+    ["later candidate", "rm a pad pad pad pad pad pad rm -rf ~", true],
+    ["second line dangerous", "rm a\nrm -rf $HOME", true],
+    ["second line dangerous after U+2028", "rm a\u2028rm -rf $HOME", true],
+    ["flags combine across ;", "rm -r a; -f ~", true],
+    ["safe", "rm -rf ./a", false],
+  ] as const)('%s', (_name, command, expected) => {
+    expect(patternById('rm-rf-home').test(command)).toBe(expected);
+  });
+
+  test('is reconsidered through the production evaluate path', () => {
+    const result = evaluateDangerous(bashCtx("rm a pad pad pad pad pad pad rm -rf ~"));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain('[rm-rf-home]');
+  });
+
+  // Separator-free near miss: 16000 candidates, none of which qualifies. Pre-change this
+  // cost 1727 ms through this same path; post-change 2.5 ms.
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx("rm a"));
+    }
+
+    const command = "rm a ".repeat(ADVERSARIAL_REPEATS);
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});
+
+describe('aws-s3-rm-recursive matcher shape', () => {
+  test.each([
+    ["later candidate in same segment", "aws s3 rm a aws s3 rm b --recursive", true],
+    ["LF between aws and s3", "aws\ns3 rm b --recursive", true],
+    ["CRLF between aws and s3", "aws\r\ns3 rm b --recursive", true],
+    ["CR between aws and s3", "aws\rs3 rm b --recursive", true],
+    ["LF between s3 and rm", "aws s3\nrm b --recursive", true],
+    ["CRLF between s3 and rm", "aws s3\r\nrm b --recursive", true],
+    ["CR between s3 and rm", "aws s3\rrm b --recursive", true],
+    ["spaced LF in both gaps", "aws \n s3 \n rm b --recursive", true],
+    ["U+2028 between aws and s3", "aws\u2028s3 rm b --recursive", true],
+    ["flag combines across ;", "aws s3 rm a; --recursive", true],
+    ["flag combines across &&", "aws s3 rm a && --recursive", true],
+    ["flag combines across |", "aws s3 rm a | --recursive", true],
+    ["flag isolated by LF", "aws s3 rm a\n--recursive", false],
+    ["flag isolated by CRLF", "aws s3 rm a\r\n--recursive", false],
+    ["flag isolated by CR", "aws s3 rm a\r--recursive", false],
+    ["flag isolated by U+2028", "aws s3 rm a\u2028--recursive", false],
+    ["second line dangerous", "aws s3 rm a\naws s3 rm --recursive", true],
+    ["second line dangerous after U+2028", "aws s3 rm a\u2028aws s3 rm --recursive", true],
+    ["far apart flag", "aws s3 rm pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad --recursive", true],
+    ["safe", "aws s3 rm a", false],
+  ] as const)('%s', (_name, command, expected) => {
+    expect(patternById('aws-s3-rm-recursive').test(command)).toBe(expected);
+  });
+
+  test('is reconsidered through the production evaluate path', () => {
+    const result = evaluateDangerous(bashCtx("aws s3 rm a aws s3 rm b --recursive"));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain('[aws-s3-rm-recursive]');
+  });
+
+  // Separator-free near miss: 16000 candidates, none of which qualifies. Pre-change this
+  // cost 5708 ms through this same path; post-change 6.4 ms.
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx("aws s3 rm a"));
+    }
+
+    const command = "aws s3 rm a ".repeat(ADVERSARIAL_REPEATS);
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});
+
+describe('kubectl-delete-prod matcher shape', () => {
+  test.each([
+    ["later candidate in same segment", "kubectl delete pod kubectl delete --all", true],
+    ["LF between kubectl and delete", "kubectl\ndelete pod --all", true],
+    ["CRLF between kubectl and delete", "kubectl\r\ndelete pod --all", true],
+    ["CR between kubectl and delete", "kubectl\rdelete pod --all", true],
+    ["spaced LF", "kubectl \n delete pod --all", true],
+    ["U+2028 between kubectl and delete", "kubectl\u2028delete pod --all", true],
+    ["flag combines across ;", "kubectl delete pod; --all", true],
+    ["flag combines across &&", "kubectl delete pod && --all", true],
+    ["flag combines across |", "kubectl delete pod | --all", true],
+    ["flag isolated by LF", "kubectl delete pod\n--all", false],
+    ["flag isolated by CRLF", "kubectl delete pod\r\n--all", false],
+    ["flag isolated by CR", "kubectl delete pod\r--all", false],
+    ["second line dangerous", "kubectl delete a\nkubectl delete --all", true],
+    ["second line dangerous after U+2028", "kubectl delete a\u2028kubectl delete --all", true],
+    ["far apart flag", "kubectl delete pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad --all", true],
+    ["safe", "kubectl delete pod x", false],
+  ] as const)('%s', (_name, command, expected) => {
+    expect(patternById('kubectl-delete-prod').test(command)).toBe(expected);
+  });
+
+  test('is reconsidered through the production evaluate path', () => {
+    const result = evaluateDangerous(bashCtx("kubectl delete pod kubectl delete --all"));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain('[kubectl-delete-prod]');
+  });
+
+  // Separator-free near miss: 16000 candidates, none of which qualifies. Pre-change this
+  // cost 1953 ms through this same path; post-change 9.6 ms.
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx("kubectl delete a"));
+    }
+
+    const command = "kubectl delete a ".repeat(ADVERSARIAL_REPEATS);
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});
+
+describe('dd-of-dev matcher shape', () => {
+  test.each([
+    ["later candidate in same segment", "dd if=a dd of=/dev/sda", true],
+    ["target combines across ;", "dd a; of=/dev/sda", true],
+    ["target combines across &&", "dd a && of=/dev/sda", true],
+    ["target isolated by LF", "dd a\nof=/dev/sda", false],
+    ["target isolated by CRLF", "dd a\r\nof=/dev/sda", false],
+    ["target isolated by CR", "dd a\rof=/dev/sda", false],
+    ["target isolated by U+2028", "dd a\u2028of=/dev/sda", false],
+    ["second line dangerous", "dd a\ndd of=/dev/sda", true],
+    ["second line dangerous after U+2028", "dd a\u2028dd of=/dev/sda", true],
+    ["far apart target", "dd pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad of=/dev/sda", true],
+    ["safe", "dd if=a of=./b", false],
+  ] as const)('%s', (_name, command, expected) => {
+    expect(patternById('dd-of-dev').test(command)).toBe(expected);
+  });
+
+  test('is reconsidered through the production evaluate path', () => {
+    const result = evaluateDangerous(bashCtx("dd if=a dd of=/dev/sda"));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain('[dd-of-dev]');
+  });
+
+  // Separator-free near miss: 16000 candidates, none of which qualifies. Pre-change this
+  // cost 590 ms through this same path; post-change 2.8 ms.
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx("dd a"));
+    }
+
+    const command = "dd a ".repeat(ADVERSARIAL_REPEATS);
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});
+
+describe('curl-pipe-shell matcher shape', () => {
+  test.each([
+    ["later candidate in same segment", "curl a pad pad pad pad pad pad curl b | sh", true],
+    ["LF right after curl", "curl\na | sh", true],
+    ["CRLF right after curl", "curl\r\na | sh", false],
+    ["CR right after curl", "curl\ra | sh", true],
+    ["U+2028 right after curl", "curl\u2028a | sh", true],
+    ["pipe on next line", "curl a\n| sh", true],
+    ["shell on next line", "curl a |\nsh", true],
+    ["pipe combines across ;", "curl a; | sh", true],
+    ["pipe two tokens past LF", "curl a\nx | sh", false],
+    ["second line dangerous", "curl a\ncurl b | sh", true],
+    ["second line dangerous after U+2028", "curl a\u2028curl b | sh", true],
+    ["far apart pipe", "curl pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad | sh", true],
+    ["safe", "curl a | shx", false],
+  ] as const)('%s', (_name, command, expected) => {
+    expect(patternById('curl-pipe-shell').test(command)).toBe(expected);
+  });
+
+  test('is reconsidered through the production evaluate path', () => {
+    const result = evaluateDangerous(bashCtx("curl a pad pad pad pad pad pad curl b | sh"));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain('[curl-pipe-shell]');
+  });
+
+  // Separator-free near miss: 16000 candidates, none of which qualifies. Pre-change this
+  // cost 858 ms through this same path; post-change 3.8 ms.
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx("curl a"));
+    }
+
+    const command = "curl a ".repeat(ADVERSARIAL_REPEATS);
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});
+
+describe('dropdb matcher shape', () => {
+  test.each([
+    ["later candidate in same quote-free run", "psql a psql b drop table t", true],
+    ["drop isolated by single quote", "psql a' drop table t", false],
+    ["drop isolated by double quote", "psql a\" drop table t", false],
+    ["second run dangerous", "psql a' psql drop table t", true],
+    ["drop combines across LF", "psql a\ndrop table t", true],
+    ["drop combines across ;", "psql a; drop table t", true],
+    ["far apart drop", "psql pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad drop table t", true],
+    ["plain dropdb", "dropdb x", true],
+    ["safe", "psql a select 1", false],
+  ] as const)('%s', (_name, command, expected) => {
+    expect(patternById('dropdb').test(command)).toBe(expected);
+  });
+
+  test('is reconsidered through the production evaluate path', () => {
+    const result = evaluateDangerous(bashCtx("dropdb x"));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain('[dropdb]');
+  });
+
+  // Separator-free near miss: 16000 candidates, none of which qualifies. Pre-change this
+  // cost 1593 ms through this same path; post-change 4.1 ms.
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx("psql a"));
+    }
+
+    const command = "psql a ".repeat(ADVERSARIAL_REPEATS);
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});
+
+describe('sql-alter-drop-col matcher shape', () => {
+  test.each([
+    ["later candidate in same statement", "alter table a add x alter table b drop column c", true],
+    ["drop isolated by ;", "alter table a; drop column c", false],
+    ["second statement dangerous", "alter table a;alter table b drop column c", true],
+    ["drop combines across LF", "alter table a\ndrop column c", true],
+    ["drop combines across CRLF", "alter table a\r\ndrop column c", true],
+    ["drop combines across &&", "alter table a && drop column c", true],
+    ["drop combines across |", "alter table a | drop column c", true],
+    ["LF between alter and table", "alter\ntable a drop column c", true],
+    ["far apart drop", "alter table pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad drop column c", true],
+    ["safe", "alter table a add column c", false],
+  ] as const)('%s', (_name, command, expected) => {
+    expect(patternById('sql-alter-drop-col').test(command)).toBe(expected);
+  });
+
+  test('is reconsidered through the production evaluate path', () => {
+    const result = evaluateDangerous(bashCtx("alter table a add x alter table b drop column c"));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain('[sql-alter-drop-col]');
+  });
+
+  // Separator-free near miss: 16000 candidates, none of which qualifies. Pre-change this
+  // cost 3184 ms through this same path; post-change 8.3 ms.
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx("alter table t"));
+    }
+
+    const command = "alter table t ".repeat(ADVERSARIAL_REPEATS);
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});
+
+describe('sql-delete-no-where matcher shape', () => {
+  test.each([
+    ["later candidate is the guarded one", "delete from a where x delete from b", true],
+    ["later candidate is guarded, earlier is not", "delete from a delete from b where x", false],
+    ["isolated by ;", "delete from a where x; delete from b", true],
+    ["where crosses LF", "delete from a\nwhere x", false],
+    ["where crosses &&", "delete from a && where x", false],
+    ["LF between delete and from", "delete\nfrom a", true],
+    ["far apart where", "delete from a pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad where x", false],
+    ["guarded", "delete from a where x", false],
+    ["unguarded", "delete from a", true],
+  ] as const)('%s', (_name, command, expected) => {
+    expect(patternById('sql-delete-no-where').test(command)).toBe(expected);
+  });
+
+  test('is reconsidered through the production evaluate path', () => {
+    const result = evaluateDangerous(bashCtx("delete from a where x delete from b"));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain('[sql-delete-no-where]');
+  });
+
+  // Separator-free near miss: 16000 candidates, none of which qualifies. Pre-change this
+  // cost 1077 ms through this same path; post-change 9.4 ms.
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx("delete from a"));
+    }
+
+    const command = "delete from a ".repeat(ADVERSARIAL_REPEATS) + "where x";
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});
+
+describe('sql-update-no-where matcher shape', () => {
+  test.each([
+    ["later candidate is the guarded one", "update a set x where q update b set y", true],
+    ["later candidate is guarded, earlier is not", "update a set x update b set y where q", false],
+    ["straddling ; operand", "update a set x update b;c set y where z", true],
+    ["isolated by ;", "update a set x where q; update b set y", true],
+    ["where crosses LF", "update a set x\nwhere q", false],
+    ["LF between update and set", "update\na\nset x", true],
+    ["far apart where", "update a set pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad where x", false],
+    ["guarded", "update a set x where q", false],
+    ["unguarded", "update a set x", true],
+  ] as const)('%s', (_name, command, expected) => {
+    expect(patternById('sql-update-no-where').test(command)).toBe(expected);
+  });
+
+  test('is reconsidered through the production evaluate path', () => {
+    const result = evaluateDangerous(bashCtx("update a set x where q update b set y"));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain('[sql-update-no-where]');
+  });
+
+  // Separator-free near miss: 16000 candidates, none of which qualifies. Pre-change this
+  // cost 1126 ms through this same path; post-change 9.6 ms.
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx("update a set b"));
+    }
+
+    const command = "update a set b ".repeat(ADVERSARIAL_REPEATS) + "where x";
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});
+
+describe('git-force-push matcher shape', () => {
+  test.each([
+    ["later candidate in same segment", "git push a git push --force origin main", true],
+    ["refspec viable only at later candidate", "git push +foo git push origin +main", true],
+    ["non-whitespace-followed first candidate", "git push;git push --force", true],
+    ["flag combines across ;", "git push a; echo --force", true],
+    ["flag combines across &&", "git push a && echo -f", true],
+    ["flag combines across |", "git push a | echo -f", true],
+    ["flag on next line", "git push origin\n--force", true],
+    ["flag on next line CRLF", "git push origin\r\n--force", true],
+    ["LF between git and push", "git\npush --force", true],
+    ["CRLF between git and push", "git\r\npush --force", true],
+    ["CR between git and push", "git\rpush --force", true],
+    ["refspec across LF", "git push origin\n+main", true],
+    ["chained blocked candidates", "git push +a git push +b git push origin +main", true],
+    ["far apart flag", "git push pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad --force", true],
+    ["force-with-lease is safe", "git push --force-with-lease origin main", false],
+    ["bare +repo is safe", "git push +main", false],
+    ["bare +repo with a later refspec is safe", "git push +main +other", false],
+    ["bare +repo with operands is safe", "git push +main origin x", false],
+    ["safe", "git push origin main", false],
+  ] as const)('%s', (_name, command, expected) => {
+    expect(patternById('git-force-push').test(command)).toBe(expected);
+  });
+
+  test('is reconsidered through the production evaluate path', () => {
+    const result = evaluateDangerous(bashCtx("git push a git push --force origin main"));
+    expect(result?.kind).toBe('deny');
+    expect((result as { kind: 'deny'; reason: string }).reason).toContain('[git-force-push]');
+  });
+
+  // Separator-free near miss: 16000 candidates, none of which qualifies. Pre-change this
+  // cost 8965 ms through this same path; post-change 6.9 ms.
+  test('separator-free near matches stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(bashCtx("git push a"));
+    }
+
+    const command = "git push a ".repeat(ADVERSARIAL_REPEATS);
+    const start = performance.now();
+    const result = evaluateDangerous(bashCtx(command));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});
+
+describe('gpg-private matcher shape', () => {
+  const gpgPrivate = DANGEROUS_PATHS.find((pattern) => pattern.id === 'gpg-private')!.re;
+
+  test.each([
+    ["later candidate on the same line", "/.gnupg/a/pad/pad/pad/pad/pad/pad/.gnupg/b.key", true],
+    ["later candidate segment on the same line", "/.gnupg/a/.gnupg/b.key", true],
+    ["second line dangerous", "/.gnupg/a\n/.gnupg/b.key", true],
+    ["second line dangerous CRLF", "/.gnupg/a\r\n/.gnupg/b.key", true],
+    ["second line dangerous CR", "/.gnupg/a\r/.gnupg/b.key", true],
+    ["second segment dangerous after U+2028", "/.gnupg/a\u2028/.gnupg/b.key", true],
+    ["second segment dangerous after U+2029", "/.gnupg/a\u2029/.gnupg/b.key", true],
+    ["key isolated by LF", "/.gnupg/a\n.key", false],
+    ["key isolated by CRLF", "/.gnupg/a\r\n.key", false],
+    ["key isolated by U+2028", "/.gnupg/a\u2028.key", false],
+    ["key combines across ;", "/.gnupg/a; b.key", true],
+    ["key combines across |", "/.gnupg/a | b.key", true],
+    ["far apart key", "/.gnupg/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/pad/a.key", true],
+    ["literal private-keys dir", "/.gnupg/private-keys-v1.d/", true],
+    ["deeply nested key", "/home/u/.gnupg/x/y/z/secring.key", true],
+    ["safe", "/.gnupg/nokey", false],
+  ] as const)('%s', (_name, filePath, expected) => {
+    expect(gpgPrivate.test(filePath)).toBe(expected);
+  });
+
+  test('is advised through the production evaluate path', () => {
+    const result = evaluateDangerous(writeCtx('/home/u/.gnupg/x/y/secring.key'));
+    expect(result?.kind).toBe('advise');
+    expect((result as { kind: 'advise'; message: string }).message).toContain('[gpg-private]');
+  });
+
+  // Deeply repeated near miss: 16000 candidates, no `.key` anywhere. Pre-change this
+  // cost 2046 ms; post-change 0.3 ms.
+  test('repeated .gnupg segments stay within the PreToolUse latency budget', () => {
+    for (let i = 0; i < 100; i += 1) {
+      evaluateDangerous(writeCtx('/tmp/x'));
+    }
+
+    const filePath = "/.gnupg/a".repeat(ADVERSARIAL_REPEATS);
+    const start = performance.now();
+    const result = evaluateDangerous(writeCtx(filePath));
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toBeNull();
+    expect(elapsedMs).toBeLessThan(LATENCY_BUDGET_MS);
+  });
+});


### PR DESCRIPTION
## Why

`git-branch-delete` was fixed in #320. It was not alone. Measuring every entry in `patterns.ts` through the production `evaluateDangerous` path found the same unbounded-rescan shape in **12 more matchers**, one of them in `DANGEROUS_PATHS` where nobody had looked.

The user-visible consequence is that #320 changed nothing yet. `matchPatterns` is first-match-wins and `git-force-push` sits at index 9 against `git-branch-delete` at index 12, so any command containing `git push` paid 2.2 s before the fixed pattern was reached.

| matcher | k=8000, before | after |
| --- | ---: | ---: |
| `git-force-push` | 2,203.9 ms | 0.59 ms |
| `sql-alter-drop-col` | 364.1 ms | 0.12 ms |
| `aws-s3-rm-recursive` | 348.3 ms | 0.23 ms |
| `rm-rf-recursive` | 147.6 ms | 0.05 ms |

Every affected matcher begins candidate discovery at a bare keyword, then runs an unbounded forward scan from each candidate. With *n* candidates on separator-free input, candidate *i* rescans the suffix candidate *i-1* already rescanned. Doubling the input quadruples the time.

## What changed

Thirteen matchers, all pure matcher-shape changes. No policy, separator set, or flag predicate was touched. Seven `DANGEROUS_BASH` entries and six `DANGEROUS_PATHS` entries were measured and left alone because the defect is not present — they have no forward scan, so a failed candidate costs O(1).

Most were the #320 treatment: anchor candidate discovery to the first candidate per boundary-delimited window, with a cross-line alternative preserving whitespace that straddles CR/LF. Two cases were not.

**`git-force-push` needed a different design, and the obvious fix is unsafe.** Its refspec branch is not an existential check. `(?:\s+-\S+)*` is deterministic, so the repository operand is pinned to the first non-flag token after `git push`, and `(?!['"]?\+)` is then applied to that specific token. A candidate whose first non-flag token starts with `+` is dead while a later candidate is still live. Anchoring to the first candidate therefore drops real matches:

```
input                                          original  first-candidate  this PR
"git push +foo git push origin +main"            true         false         true
"git push;git push --force"                      true         false         true
"git push +a git push +b git push origin +c"     true         false         true
"git push -q +x git push origin +main"           true         false         true
```

Four force-pushes silently permitted. This PR uses two independently-anchored branches, each anchored to the first candidate *its own branch* can satisfy. Soundness argument for the refspec branch, in the code comment and restated here: among candidates that satisfy the head, `f(q1) <= f(q2)` where `f` is the first non-flag token; `f(q1)` is legal because `q1` is viable; so any `+`-witness after `f(q2)` is reachable from `f(q1)`.

**`sql-delete-no-where` and `sql-update-no-where` are the inverse case.** Their guard is a negative lookahead, so it is anti-monotone — a later candidate can be guarded where an earlier one is not. Selecting the first candidate would report danger that the original did not. These select the **last** candidate instead, via a self-limiting no-later-candidate check.

Also `dropdb`, whose window is quote-bounded rather than line-bounded, and `sql-alter-drop-col`, whose window is statement-bounded.

## Behavioral equivalence

8,789,543 differential inputs against the pre-change matchers — exhaustive short sequences over each pattern's own vocabulary plus 500,000 seeded sequences per pattern, CR, LF, CRLF, U+2028 and U+2029 in every alphabet. **Zero divergence in both directions.**

The harness was mutation-checked before its zero was believed: a narrowed matcher surfaced 217/165/4,320 false negatives on three patterns, a widened one surfaced 27,022/30,989/20,899 false positives. Per-pattern targeted mutants — bounded window, dropped cross-line alternative, `\r\n`-only break class, input-start-only anchoring, single shared prefix — were each killed.

Field-by-field comparison of all 33 entries across the three arrays: 16 regex sources changed, all intended; **zero** changes to any `id`, `label`, `reason`, `policy`, or regex flag. The three `content-sql-*` entries share RegExp objects with their `DANGEROUS_BASH` counterparts and change with them by construction.

Two mutants were written, survived, and are reported rather than dropped quietly: `dd`'s prefix-crosses-line-breaks and `dropdb`'s segment-prefix-crosses-quotes. Both are genuinely behaviour-equivalent — the entry-point alternation still offers an entry at every boundary — so no behavioural test can kill them. They are pure performance regressions, and the latency tests are their guard.

## Tests

`tests/dangerous-actions-matcher-scaling.test.ts`, 184 tests. Every expectation was computed from the pre-change matcher and cross-checked against the new one before being written, so the file is a characterization of existing behaviour rather than an assertion of intended behaviour.

All 184 are proven load-bearing by 34 mutants run through the real runner. Restoring `patterns.ts` verbatim fails all 13 latency tests and **zero** behavioural tests — which is simultaneously the proof that the characterization is faithful and that every latency test catches a revert. A fixed scan-distance bound, the shape rejected in #320 review, kills 32 tests.

## Validation

- `npm run check` — clean
- `npm run test` — 35 files, 1,441 tests passing, 45 bundles built (baseline was 34 / 1,257 / 45)
- `git diff --check` — clean
- DCO trailers on both commits

`src/hooks/dist/` is generated and untracked, and no compiled hook JS is tracked under `plugins/`, so no plugin regeneration is owed. `docs/hooks/*.md` and `docs/hooks-verify.md` document I/O contracts, not matcher internals; the one regex they quote is `ssh-private-key`, which is unchanged.

## Blast radius

This is a PreToolUse guard running before every Bash call in every IDE the plugin supports. A false negative permits an unreviewed destructive command. Every change is `prefix + keyword + unmodified original lookahead`, so a match implies the original matched at the same position — only false negatives were ever at risk, which is what the monotonicity arguments and the differential address.

## Where to look hardest

1. The `git-force-push` refspec monotonicity claim, specifically whether `(?:\s+-\S+)*` can land the operand anywhere other than the first non-dash token.
2. `sql-update-no-where`'s `[^;\s]+` guard. The straddling-`;` witness took two attempts to construct; the real one is `update a set x update b;c set y where z`.
3. `curl-pipe-shell`'s split of a single `\s` into disjoint line-local and line-break halves.

## Out of scope, found while working

- `docs/ARCHITECTURE.md:362` describes `curl | sh` as `hard-deny`, contradicting `patterns.ts:11` ("there is intentionally no unconditional-block tier") and that pattern's actual `reconsider` policy. Pre-existing.
- `tests/lint-format-advisory.test.ts` fails on any run started within 5 s of a previous one — `acquireOnce` writes a 5,000 ms TTL lock into `os.tmpdir()` while the suite finishes in ~1.2 s. Pre-existing, and it makes any "suite is green" claim timing-dependent.

Follow-up to #320. Authored with AI assistance; measurements and the equivalence differential were reproduced independently before opening.
