### PR TITLE
fix(hooks): restrict MultiEdit AI-reviewed marker source

### DIFF
--- a/src/hooks/src/hooks/dangerous-actions/evaluate.ts
+++ b/src/hooks/src/hooks/dangerous-actions/evaluate.ts
@@ -117,6 +117,10 @@ export function hasAIReviewedMarker(
       return v.some(item => {
         if (typeof item === 'string') return MARKER_RE.test(item);
         if (item && typeof item === 'object') {
+          if (toolName === 'MultiEdit') {
+            const newString = (item as Record<string, unknown>).new_string;
+            return typeof newString === 'string' && MARKER_RE.test(newString);
+          }
           return Object.values(item as Record<string, unknown>)
             .some(inner => typeof inner === 'string' && MARKER_RE.test(inner));
         }

--- a/src/hooks/tests/dangerous-actions.test.ts
+++ b/src/hooks/tests/dangerous-actions.test.ts
@@ -624,6 +624,34 @@ describe('Rosetta-AI-reviewed — retry marker', () => {
     expect(evaluateDangerous(ctx)).toBeNull();
   });
 
+  test('MultiEdit: marker only in edit.old_string → deny (write-field boundary locked)', () => {
+    const ctx: HookContext = {
+      ide: 'claude-code', event: 'PreToolUse', toolKind: 'multi-edit',
+      toolName: 'MultiEdit', filePath: 'schema.sql', cwd: '/proj', sessionId: null,
+      toolInput: {
+        file_path: 'schema.sql',
+        edits: [
+          { old_string: 'DROP TABLE x; -- Rosetta-AI-reviewed', new_string: 'DROP TABLE x;' },
+        ],
+      },
+    };
+    expect(evaluateDangerous(ctx)).not.toBeNull();
+  });
+
+  test('MultiEdit: marker only in an unrelated edit field → deny', () => {
+    const ctx: HookContext = {
+      ide: 'claude-code', event: 'PreToolUse', toolKind: 'multi-edit',
+      toolName: 'MultiEdit', filePath: 'schema.sql', cwd: '/proj', sessionId: null,
+      toolInput: {
+        file_path: 'schema.sql',
+        edits: [
+          { old_string: 'a', new_string: 'DROP TABLE x;', description: 'Rosetta-AI-reviewed' },
+        ],
+      },
+    };
+    expect(evaluateDangerous(ctx)).not.toBeNull();
+  });
+
   test('hasAIReviewedMarker: tab-separated marker → true', () => {
     expect(hasAIReviewedMarker({ command: 'rm -rf /tmp/x\t# Rosetta-AI-reviewed' }, 'Bash')).toBe(true);
   });


### PR DESCRIPTION
## Problem

`Edit` accepts the `Rosetta-AI-reviewed` override marker only from `new_string`, but `MultiEdit` previously scanned every property of each `edits[]` object. A marker in `old_string` or another property could therefore satisfy the reconsider-deny override without appearing in content being written.

## Root cause

`hasAIReviewedMarker` used `Object.values(item)` for object entries in array-valued marker fields. `MARKER_FIELDS_BY_TOOL` identifies `MultiEdit.edits` as the relevant top-level field, but the nested traversal did not enforce the same write-field boundary as plain `Edit`.

## Fix

For `MultiEdit`, marker detection now checks only each edit item's string `new_string`. The existing behavior for plain `Edit`, MCP marker fields, and other array-shaped inputs is unchanged.

This is a focused defense-in-depth correctness fix; it does not change the marker string or redesign dangerous-action policy.

## Regression coverage

- marker only in `MultiEdit.edits[].old_string` remains denied;
- marker only in an unrelated edit property remains denied;
- marker in one `MultiEdit.edits[].new_string` remains accepted;
- existing plain `Edit` positive and old-string negative cases remain green;
- existing dangerous-actions coverage remains green.

## Verification

- `npx tsc` — passed;
- `npx vitest run tests/dangerous-actions.test.ts` — 198 passed;
- `npx vitest run tests/regression/bundle-isolation.test.ts` after bundle build — 193 passed;
- full hooks Vitest suite — 1,403 passed, 40 failures;
- a clean untouched worktree at the same upstream SHA reproduced the same 40 failures, all in existing Windows path/async assumptions outside this change;
- `npm run check` — passed;
- `git diff --check` — passed;
- bundle build stages (`tsc` plus `build-bundles.mjs`) — passed;
- the repository's `build:quiet` and pre-commit wrapper cannot complete on this Windows host because their Unix `rm` command is not available; the TypeScript and bundle stages succeeded directly.

Fixes #210

Codex assisted with repository analysis, implementation, regression tests, and validation. I directed the scope and reviewed the final diff and PR text.
