### PR TITLE
#173 [ROSETTA] dangerous-actions hook: MCP cmd/shell_command fields can't carry override marker

### DIFF
--- a/src/hooks/src/hooks/dangerous-actions/evaluate.ts
+++ b/src/hooks/src/hooks/dangerous-actions/evaluate.ts
@@ -26,11 +26,12 @@ const MARKER_FIELDS_BY_TOOL: Readonly<Record<string, readonly string[]>> = {
   MultiEdit: ['edits'],
 };
 
-const MCP_MARKER_FIELDS = ['command', 'sql', 'query', 'new_string', 'content'] as const;
-
 const MCP_SHELL_FIELDS   = ['command', 'cmd', 'shell_command'] as const;
 const MCP_PATH_FIELDS    = ['path', 'file_path', 'filePath', 'target', 'target_path'] as const;
 const MCP_CONTENT_FIELDS = ['content', 'new_string', 'query', 'sql'] as const;
+// Markers are accepted only in writable MCP payload fields. Paths remain excluded
+// so an override cannot be carried solely by changing an operation target.
+const MCP_MARKER_FIELDS = [...new Set([...MCP_SHELL_FIELDS, ...MCP_CONTENT_FIELDS])] as const;
 
 type PatternHit = { result: HookResult; pattern: DangerPattern | null };
 

--- a/src/hooks/tests/dangerous-actions.test.ts
+++ b/src/hooks/tests/dangerous-actions.test.ts
@@ -650,6 +650,13 @@ describe('evaluateDangerous — MCP tool calls (mcp-call kind)', () => {
     expect((r as {kind:'deny';reason:string}).reason).toContain('rm-rf-root');
   });
 
+  test('mcp shell command with marker only in path → deny (paths cannot override)', () => {
+    expect(evaluateDangerous(mcpCtx(
+      'mcp__plugin_serena_serena__execute_shell_command',
+      { command: 'rm -rf /tmp/x', path: '/tmp/Rosetta-AI-reviewed' }
+    ))?.kind).toBe('deny');
+  });
+
   test('mcp filesystem write_file to .aws/credentials → advise aws-credentials (non-blocking)', () => {
     const r = evaluateDangerous(mcpCtx(
       'mcp__filesystem__write_file',
@@ -716,6 +723,34 @@ describe('evaluateDangerous — MCP tool calls (mcp-call kind)', () => {
       { command: 'rm -rf /tmp/x  # Rosetta-AI-reviewed' }
     ));
     expect(r).toBeNull();
+  });
+
+  test('mcp shell cmd with `# Rosetta-AI-reviewed` → null (marker applies to every MCP shell field)', () => {
+    expect(evaluateDangerous(mcpCtx(
+      'mcp__shell__run',
+      { cmd: 'rm -rf /tmp/x  # Rosetta-AI-reviewed' }
+    ))).toBeNull();
+  });
+
+  test('mcp shell cmd without marker → deny', () => {
+    expect(evaluateDangerous(mcpCtx(
+      'mcp__shell__run',
+      { cmd: 'rm -rf /tmp/x' }
+    ))?.kind).toBe('deny');
+  });
+
+  test('mcp shell shell_command with `# Rosetta-AI-reviewed` → null (marker applies to every MCP shell field)', () => {
+    expect(evaluateDangerous(mcpCtx(
+      'mcp__shell__run',
+      { shell_command: 'rm -rf /tmp/x  # Rosetta-AI-reviewed' }
+    ))).toBeNull();
+  });
+
+  test('mcp shell shell_command without marker → deny', () => {
+    expect(evaluateDangerous(mcpCtx(
+      'mcp__shell__run',
+      { shell_command: 'rm -rf /tmp/x' }
+    ))?.kind).toBe('deny');
   });
 
   // Obj9: MCP marker in query field (not just command)


### PR DESCRIPTION
Closes #173

## Summary

- Derive MCP marker-eligible fields from the shell and content field sets.
- Add marked and unmarked `cmd` and `shell_command` regression coverage.
- Assert that a marker in an MCP path cannot override a dangerous command.

## Testing

- `npm --prefix src/hooks run check`
- `npm --prefix src/hooks exec vitest run tests/dangerous-actions.test.ts` (201 passed)
- `python3 scripts/pre_commit.py` with a writable temporary npm cache (35 files, 1,446 hook tests passed)

## Assumptions

- `MCP_PATH_FIELDS` remains intentionally excluded from marker eligibility, as specified in the approved plan.
- The extracted runner has no root Python virtual environment, so repository Python checks were skipped by the existing validation script; hook validation completed.